### PR TITLE
fix: path mapping source_os renamed to source_path_format

### DIFF
--- a/src/openjd/adaptor_runtime/adaptors/_path_mapping.py
+++ b/src/openjd/adaptor_runtime/adaptors/_path_mapping.py
@@ -45,13 +45,13 @@ class PathMappingRule:
     def __init__(
         self,
         *,
-        source_os: str,
+        source_path_format: str,
         source_path: str,
         destination_path: str,
         destination_os: str = OSName(),
     ):
         for label, value in (
-            ("source_os", source_os),
+            ("source_path_format", source_path_format),
             ("source_path", source_path),
             ("destination_path", destination_path),
         ):
@@ -60,8 +60,10 @@ class PathMappingRule:
 
         self.source_path: str = source_path
         self.destination_path: str = destination_path
-        self._source_os: str = OSName(source_os)  # Raises ValueError if not valid OS
-        self._is_windows_source: bool = OSName.is_windows(self._source_os)
+        self._source_path_format: str = OSName(
+            source_path_format
+        )  # Raises ValueError if not valid OS
+        self._is_windows_source: bool = OSName.is_windows(self._source_path_format)
 
         self._destination_os: str = OSName(destination_os)  # Raises ValueError if not valid OS
         self._is_windows_destination: bool = OSName.is_windows(self._destination_os)
@@ -91,13 +93,23 @@ class PathMappingRule:
         if not rule:
             raise ValueError("Empty path mapping rule")
 
+        # TODO - DELETE ONCE MIGRATION COMPLETE
+        # The field "source_os" was renamed to "source_path_format", but interfaces may still
+        # provide the old name until they're updated. Remove once we're sure all interfaces are
+        # updated.
+        if "source_os" in rule:
+            new_rule = dict(**rule)
+            new_rule["source_path_format"] = new_rule["source_os"]
+            del new_rule["source_os"]
+            rule = new_rule
+        # END TODO
         return PathMappingRule(**rule)
 
     def to_dict(self) -> dict[str, str]:
         """Builds a PathMappingRule given a dict with the fields required by __init__
         raises TypeError, ValueError: if rule is None, an empty dict, or nonvalid"""
         return {
-            "source_os": self._source_os,
+            "source_path_format": self._source_path_format,
             "source_path": self.source_path,
             "destination_os": self._destination_os,
             "destination_path": self.destination_path,

--- a/src/openjd/adaptor_runtime_client/client_interface.py
+++ b/src/openjd/adaptor_runtime_client/client_interface.py
@@ -33,7 +33,7 @@ _REQUEST_TIMEOUT = None
 # due to some applications running an older Python version that can't import newer typing
 @_dataclass
 class PathMappingRule:
-    source_os: str
+    source_path_format: str
     source_path: str
     destination_path: str
     destination_os: str

--- a/test/openjd/adaptor_runtime/integ/adaptors/test_integration_path_mapping.py
+++ b/test/openjd/adaptor_runtime/integ/adaptors/test_integration_path_mapping.py
@@ -34,7 +34,7 @@ class TestGetPathMappingRules:
         # GIVEN
         path_mapping_rules = [
             {
-                "source_os": "linux",
+                "source_path_format": "linux",
                 "source_path": "/mnt/shared/asset_storage1",
                 "destination_os": "windows",
                 "destination_path": "Z:\\asset_storage1",
@@ -59,13 +59,13 @@ class TestGetPathMappingRules:
         # GIVEN
         path_mapping_rules = [
             {
-                "source_os": "linux",
+                "source_path_format": "linux",
                 "source_path": "/mnt/shared/asset_storage0",
                 "destination_os": "windows",
                 "destination_path": "Z:\\asset_storage0",
             },
             {
-                "source_os": "linux",
+                "source_path_format": "linux",
                 "source_path": "/mnt/shared/asset_storage1",
                 "destination_os": "windows",
                 "destination_path": "Z:\\asset_storage1",
@@ -84,13 +84,13 @@ class TestGetPathMappingRules:
     def test_get_order_is_preserved(self) -> None:
         # GIVEN
         rule1 = {
-            "source_os": "linux",
+            "source_path_format": "linux",
             "source_path": "/mnt/shared/asset_storage1",
             "destination_os": "windows",
             "destination_path": "Z:\\asset_storage1",
         }
         rule2 = {
-            "source_os": "windows",
+            "source_path_format": "windows",
             "source_path": "Z:\\asset_storage1",
             "destination_os": "windows",
             "destination_path": "Z:\\should\\not\\reach\\this",
@@ -120,7 +120,7 @@ class TestGetPathMappingRules:
         adaptor = FakeCommandAdaptor(expected)
         rules = adaptor.path_mapping_rules
         new_rule = PathMappingRule(
-            source_os="linux",
+            source_path_format="linux",
             source_path="/mnt/shared/asset_storage1",
             destination_os="windows",
             destination_path="Z:\\asset_storage1",
@@ -154,7 +154,7 @@ class TestApplyPathMapping:
         # GIVEN
         path_mapping_rules = [
             {
-                "source_os": "linux",
+                "source_path_format": "linux",
                 "source_path": "/mnt/shared/asset_storage1",
                 "destination_os": "windows",
                 "destination_path": "Z:\\asset_storage1",
@@ -174,7 +174,7 @@ class TestApplyPathMapping:
         # GIVEN
         path_mapping_rules = [
             {
-                "source_os": "windows",
+                "source_path_format": "windows",
                 "source_path": "Z:\\asset_storage1",
                 "destination_os": "linux",
                 "destination_path": "/mnt/shared/asset_storage1",
@@ -194,7 +194,7 @@ class TestApplyPathMapping:
         # GIVEN
         path_mapping_rules = [
             {
-                "source_os": "linux",
+                "source_path_format": "linux",
                 "source_path": "/mnt/shared/my_custom_path/asset_storage1",
                 "destination_os": "linux",
                 "destination_path": "/mnt/shared/asset_storage1",
@@ -215,7 +215,7 @@ class TestApplyPathMapping:
         # GIVEN
         path_mapping_rules = [
             {
-                "source_os": "windows",
+                "source_path_format": "windows",
                 "source_path": "Z:\\my_custom_asset_path\\asset_storage1",
                 "destination_os": "windows",
                 "destination_path": "Z:\\asset_storage1",
@@ -235,7 +235,7 @@ class TestApplyPathMapping:
         # GIVEN
         path_mapping_rules = [
             {
-                "source_os": "windows",
+                "source_path_format": "windows",
                 "source_path": "Z:\\my_custom_asset_path\\asset_storage1",
                 "destination_os": "windows",
                 "destination_path": "Z:\\asset_storage1",
@@ -255,7 +255,7 @@ class TestApplyPathMapping:
         # GIVEN
         path_mapping_rules = [
             {
-                "source_os": "windows",
+                "source_path_format": "windows",
                 "source_path": "Z:\\my_custom_asset_path\\asset_storage1",
                 "destination_os": "windows",
                 "destination_path": "Z:\\asset_storage1",
@@ -275,13 +275,13 @@ class TestApplyPathMapping:
         # GIVEN
         path_mapping_rules = [
             {
-                "source_os": "linux",
+                "source_path_format": "linux",
                 "source_path": "/mnt/shared/asset_storage0",
                 "destination_os": "windows",
                 "destination_path": "Z:\\asset_storage0",
             },
             {
-                "source_os": "linux",
+                "source_path_format": "linux",
                 "source_path": "/mnt/shared/asset_storage1",
                 "destination_os": "windows",
                 "destination_path": "Z:\\asset_storage1",
@@ -301,13 +301,13 @@ class TestApplyPathMapping:
         # GIVEN
         path_mapping_rules = [
             {
-                "source_os": "linux",
+                "source_path_format": "linux",
                 "source_path": "/mnt/shared/asset_storage1",
                 "destination_os": "windows",
                 "destination_path": "Z:\\asset_storage1",
             },
             {
-                "source_os": "windows",
+                "source_path_format": "windows",
                 "source_path": "Z:\\asset_storage1",
                 "destination_os": "windows",
                 "destination_path": "Z:\\should\\not\\reach\\this",
@@ -327,13 +327,13 @@ class TestApplyPathMapping:
         # GIVEN
         path_mapping_rules = [
             {
-                "source_os": "linux",
+                "source_path_format": "linux",
                 "source_path": "/mnt/shared/asset_storage1",
                 "destination_os": "windows",
                 "destination_path": "Z:\\asset_storage1",
             },
             {
-                "source_os": "linux",
+                "source_path_format": "linux",
                 "source_path": "/mnt/shared/asset_storage1",
                 "destination_os": "windows",
                 "destination_path": "Z:\\should\\not\\reach\\this",

--- a/test/openjd/adaptor_runtime/integ/application_ipc/test_integration_adaptor_ipc.py
+++ b/test/openjd/adaptor_runtime/integ/application_ipc/test_integration_adaptor_ipc.py
@@ -25,13 +25,13 @@ def adaptor():
 
     path_mapping_rules = [
         {
-            "source_os": "windows",
+            "source_path_format": "windows",
             "source_path": "Z:\\asset_storage1",
             "destination_os": "linux",
             "destination_path": "/mnt/shared/asset_storage1",
         },
         {
-            "source_os": "windows",
+            "source_path_format": "windows",
             "source_path": "🌚\\🌒\\🌓\\🌔\\🌝\\🌖\\🌗\\🌘\\🌚",
             "destination_os": "linux",
             "destination_path": "🌝/🌖/🌗/🌘/🌚/🌒/🌓/🌔/🌝",

--- a/test/openjd/adaptor_runtime/unit/adaptors/test_path_mapping.py
+++ b/test/openjd/adaptor_runtime/unit/adaptors/test_path_mapping.py
@@ -10,16 +10,22 @@ from openjd.adaptor_runtime.adaptors import PathMappingRule
 @pytest.mark.parametrize(
     "rule",
     [
-        pytest.param({"source_os": "", "source_path": "", "destination_path": ""}),
-        pytest.param({"source_os": None, "source_path": None, "destination_path": None}),
-        pytest.param({"source_os": "", "source_path": None, "destination_path": ""}),
-        pytest.param({"source_os": "", "source_path": "C:/", "destination_path": "/mnt/"}),
-        pytest.param({"source_os": "windows", "source_path": "", "destination_path": "/mnt/"}),
-        pytest.param({"source_os": "windows", "source_path": "C:/", "destination_path": ""}),
-        pytest.param({"source_os": "nonvalid", "source_path": "C:/", "destination_path": "/mnt/"}),
+        pytest.param({"source_path_format": "", "source_path": "", "destination_path": ""}),
+        pytest.param({"source_path_format": None, "source_path": None, "destination_path": None}),
+        pytest.param({"source_path_format": "", "source_path": None, "destination_path": ""}),
+        pytest.param({"source_path_format": "", "source_path": "C:/", "destination_path": "/mnt/"}),
+        pytest.param(
+            {"source_path_format": "windows", "source_path": "", "destination_path": "/mnt/"}
+        ),
+        pytest.param(
+            {"source_path_format": "windows", "source_path": "C:/", "destination_path": ""}
+        ),
+        pytest.param(
+            {"source_path_format": "nonvalid", "source_path": "C:/", "destination_path": "/mnt/"}
+        ),
         pytest.param(
             {
-                "source_os": "windows",
+                "source_path_format": "windows",
                 "destination_os": "nonvalid",
                 "source_path": "C:/",
                 "destination_path": "/mnt/",
@@ -55,7 +61,7 @@ def test_no_args(rule):
 def test_good_args():
     # GIVEN
     rule = {
-        "source_os": "windows",
+        "source_path_format": "windows",
         "destination_os": "windows",
         "source_path": "Y:/movie1",
         "destination_path": "Z:/movie2",
@@ -79,7 +85,9 @@ def test_good_args():
 )
 def test_path_mapping_linux_is_match(path):
     # GIVEN
-    rule = PathMappingRule(source_os="linux", source_path="/usr", destination_path="/mnt/shared")
+    rule = PathMappingRule(
+        source_path_format="linux", source_path="/usr", destination_path="/mnt/shared"
+    )
     pure_path = PurePosixPath(path)
 
     # WHEN
@@ -104,7 +112,7 @@ def test_path_mapping_linux_is_match(path):
 def test_path_mapping_linux_is_not_match(path):
     # GIVEN
     rule = PathMappingRule(
-        source_os="linux", source_path="/usr/Movie1", destination_path="/mnt/shared/Movie1"
+        source_path_format="linux", source_path="/usr/Movie1", destination_path="/mnt/shared/Movie1"
     )
     pure_path = PurePosixPath(path)
 
@@ -130,7 +138,7 @@ def test_path_mapping_linux_is_not_match(path):
 def test_path_mapping_windows_is_match(path):
     # GIVEN
     rule = PathMappingRule(
-        source_os="windows", source_path="Z:\\Movie1", destination_path="/mnt/shared"
+        source_path_format="windows", source_path="Z:\\Movie1", destination_path="/mnt/shared"
     )
     pure_path = PureWindowsPath(path)
 
@@ -152,7 +160,7 @@ def test_path_mapping_windows_is_match(path):
 def test_path_mapping_windows_is_not_match(path):
     # GIVEN
     rule = PathMappingRule(
-        source_os="windows", source_path="Z:\\Movie1", destination_path="/mnt/shared"
+        source_path_format="windows", source_path="Z:\\Movie1", destination_path="/mnt/shared"
     )
     pure_path = PureWindowsPath(path)
 
@@ -168,7 +176,7 @@ class TestApplyPathMapping:
         # GIVEN
         rule = PathMappingRule.from_dict(
             rule={
-                "source_os": "linux",
+                "source_path_format": "linux",
                 "source_path": "/mnt/shared/asset_storage2",
                 "destination_os": "linux",
                 "destination_path": "/mnt/shared/movie2",
@@ -187,7 +195,7 @@ class TestApplyPathMapping:
         # GIVEN
         rule = PathMappingRule.from_dict(
             rule={
-                "source_os": "linux",
+                "source_path_format": "linux",
                 "source_path": "/mnt/shared/asset_storage1",
                 "destination_os": "windows",
                 "destination_path": "Z:\\asset_storage1",
@@ -206,7 +214,7 @@ class TestApplyPathMapping:
         # GIVEN
         rule = PathMappingRule.from_dict(
             rule={
-                "source_os": "windows",
+                "source_path_format": "windows",
                 "source_path": "Z:\\asset_storage1",
                 "destination_os": "linux",
                 "destination_path": "/mnt/shared/asset_storage1",
@@ -225,7 +233,7 @@ class TestApplyPathMapping:
         # GIVEN
         rule = PathMappingRule.from_dict(
             rule={
-                "source_os": "linux",
+                "source_path_format": "linux",
                 "source_path": "/mnt/shared/my_custom_path/asset_storage1",
                 "destination_os": "linux",
                 "destination_path": "/mnt/shared/asset_storage1",
@@ -245,7 +253,7 @@ class TestApplyPathMapping:
         # GIVEN
         rule = rule = PathMappingRule.from_dict(
             rule={
-                "source_os": "windows",
+                "source_path_format": "windows",
                 "source_path": "Z:\\my_custom_asset_path\\asset_storage1",
                 "destination_os": "windows",
                 "destination_path": "Z:\\asset_storage1",
@@ -264,7 +272,7 @@ class TestApplyPathMapping:
         # GIVEN
         rule = PathMappingRule.from_dict(
             rule={
-                "source_os": "windows",
+                "source_path_format": "windows",
                 "source_path": "Z:\\my_custom_asset_path\\asset_storage1",
                 "destination_os": "windows",
                 "destination_path": "Z:\\asset_storage1",
@@ -283,7 +291,7 @@ class TestApplyPathMapping:
         # GIVEN
         rule = PathMappingRule.from_dict(
             rule={
-                "source_os": "windows",
+                "source_path_format": "windows",
                 "source_path": "Z:\\my_custom_asset_path\\asset_storage1",
                 "destination_os": "windows",
                 "destination_path": "Z:\\asset_storage1",
@@ -302,7 +310,7 @@ class TestApplyPathMapping:
         # GIVEN
         rule = PathMappingRule.from_dict(
             rule={
-                "source_os": "windows",
+                "source_path_format": "windows",
                 "source_path": "Z:/my_custom_asset_path/asset_storage1",
                 "destination_os": "windows",
                 "destination_path": "Z:\\asset_storage1",
@@ -321,7 +329,7 @@ class TestApplyPathMapping:
         # GIVEN
         rule = PathMappingRule.from_dict(
             rule={
-                "source_os": "linux",
+                "source_path_format": "linux",
                 "source_path": "a/b",
                 "destination_os": "linux",
                 "destination_path": "/c",
@@ -340,7 +348,7 @@ class TestApplyPathMapping:
         # GIVEN
         rule = PathMappingRule.from_dict(
             rule={
-                "source_os": "linux",
+                "source_path_format": "linux",
                 "source_path": "/bar/baz",
                 "destination_os": "linux",
                 "destination_path": "/bla",
@@ -358,7 +366,7 @@ class TestApplyPathMapping:
     def test_to_dict(self):
         # GIVEN
         rule_dict = {
-            "source_os": "linux",
+            "source_path_format": "linux",
             "source_path": "/bar/baz",
             "destination_os": "linux",
             "destination_path": "/bla",

--- a/test/openjd/adaptor_runtime/unit/application_ipc/test_adaptor_http_request_handler.py
+++ b/test/openjd/adaptor_runtime/unit/application_ipc/test_adaptor_http_request_handler.py
@@ -71,7 +71,7 @@ class TestPathMappingEndpoint:
             path_mapping_data={
                 "path_mapping_rules": [
                     {
-                        "source_os": "windows",
+                        "source_path_format": "windows",
                         "source_path": SOURCE_PATH,
                         "destination_os": "linux",
                         "destination_path": DEST_PATH,
@@ -104,7 +104,7 @@ class TestPathMappingRulesEndpoint:
         SOURCE_PATH = "Z:\\asset_storage1"
         DEST_PATH = "/mnt/shared/asset_storage1"
         rules = {
-            "source_os": "Windows",
+            "source_path_format": "Windows",
             "source_path": SOURCE_PATH,
             "destination_os": "Linux",
             "destination_path": DEST_PATH,

--- a/test/openjd/adaptor_runtime_client/unit/test_client_interface.py
+++ b/test/openjd/adaptor_runtime_client/unit/test_client_interface.py
@@ -96,7 +96,7 @@ class TestClientInterface:
             (
                 [
                     {
-                        "source_os": "one",
+                        "source_path_format": "one",
                         "source_path": "here",
                         "destination_os": "two",
                         "destination_path": "there",


### PR DESCRIPTION
Must be merged *after* https://github.com/xxyggoqtpcmcofkc/openjd-adaptor-runtime-for-python/pull/1 has merged.


The field name `source_os` in a path mapping rule's definition was  determined to be somewhat ambiguous in its meaning. So, it is being  changed to `source_path_format`. This commit applies the change.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
