### PR TITLE
chore(deps): downgrade jsonschema dependency to 4.17

### DIFF
--- a/THIRD-PARTY-LICENSES.txt
+++ b/THIRD-PARTY-LICENSES.txt
@@ -1,4 +1,4 @@
-** Python-jsonschema; version 4.19 -- https://github.com/python-jsonschema/jsonschema
+** Python-jsonschema; version 4.17 -- https://github.com/python-jsonschema/jsonschema
 Copyright (c) 2013 Julian Berman
 
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ requires-python = ">=3.9"
 
 dependencies = [
   "pyyaml ~= 6.0",
-  "jsonschema >= 4.19.0, == 4.*",
+  "jsonschema >= 4.17.0, == 4.*",
 ]
 
 [tool.hatch.build]


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
`deadline-cloud` is locked to jsonschema-4.17 as it is the last version to support python 3.7. `deadline-cloud-for-nuke` has a dependency on this repo as well as `deadline-cloud`, causing conflicting dependencies. 

### What was the solution? (How)
Downgrade the jsonschema dependency to 4.17 to align with `deadline-cloud`

### What is the impact of this change?
This repo is also locked to jsonschema-4.17 until we can determine a way to mix dependencies used by the adaptor (which can run python 3.9+) vs the child process being run (such as Nuke 13 which is using python 3.7)

### How was this change tested?
- Unit tests pass
- Submitted a Nuke job, uploading the adaptor wheels.

### Was this change documented?
No

### Is this a breaking change?

Yes, dependency version is changing.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*