### PR TITLE
fix: emit openjd_* log messages without any log formatting

### DIFF
--- a/src/openjd/adaptor_runtime/_entrypoint.py
+++ b/src/openjd/adaptor_runtime/_entrypoint.py
@@ -20,6 +20,10 @@ from .adaptors.configuration import (
     ConfigurationManager,
 )
 from ._osname import OSName
+from ._utils._logging import (
+    _OPENJD_LOG_REGEX,
+    ConditionalFormatter,
+)
 
 if TYPE_CHECKING:  # pragma: no cover
     from .adaptors.configuration import AdaptorConfiguration
@@ -92,7 +96,9 @@ class EntryPoint:
         """
         Starts the run of the adaptor.
         """
-        formatter = logging.Formatter("%(levelname)s: %(message)s")
+        formatter = ConditionalFormatter(
+            "%(levelname)s: %(message)s", ignore_patterns=[_OPENJD_LOG_REGEX]
+        )
         stream_handler = logging.StreamHandler(sys.stdout)
         stream_handler.setFormatter(formatter)
 

--- a/src/openjd/adaptor_runtime/_utils/_logging.py
+++ b/src/openjd/adaptor_runtime/_utils/_logging.py
@@ -1,0 +1,37 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+import logging
+import re
+from typing import (
+    List,
+    Optional,
+)
+
+_OPENJD_LOG_PATTERN = r"^openjd_\S+: "
+_OPENJD_LOG_REGEX = re.compile(_OPENJD_LOG_PATTERN)
+
+
+class ConditionalFormatter(logging.Formatter):
+    """
+    A Formatter subclass that applies formatting conditionally.
+    """
+
+    def __init__(
+        self,
+        *args,
+        ignore_patterns: Optional[List[re.Pattern[str]]],
+        **kwargs,
+    ):
+        """
+        Args:
+            ignore_patterns (Optional[List[re.Pattern[str]]]): List of patterns that, when matched,
+                indicate a log message must not be formatted (it is "ignored" by the formatter)
+        """
+        self._ignore_patterns = ignore_patterns or []
+        super().__init__(*args, **kwargs)
+
+    def format(self, record: logging.LogRecord) -> str:
+        for ignore_pattern in self._ignore_patterns:
+            if ignore_pattern.match(record.msg):
+                return record.getMessage()
+
+        return super().format(record)

--- a/src/openjd/adaptor_runtime/adaptors/_adaptor_runner.py
+++ b/src/openjd/adaptor_runtime/adaptors/_adaptor_runner.py
@@ -81,6 +81,4 @@ class AdaptorRunner(AdaptorStates):
 
 
 def _fail(reason: str):
-    # TODO: Add a way to output "system" messages that ignore logging configuration.
-    # We don't ever want this message to get filtered out by Python's logging library.
     _logger.error(f"{_OPENJD_FAIL_STDOUT_PREFIX}{reason}")

--- a/test/openjd/adaptor_runtime/unit/utils/test_logging.py
+++ b/test/openjd/adaptor_runtime/unit/utils/test_logging.py
@@ -1,0 +1,57 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+import logging
+import re
+from typing import List
+from unittest.mock import patch
+
+import pytest
+
+import openjd.adaptor_runtime._utils._logging as logging_mod
+from openjd.adaptor_runtime._utils._logging import ConditionalFormatter
+
+
+class TestConditionalFormatter:
+    @pytest.mark.parametrize(
+        ["patterns", "message", "should_be_ignored"],
+        [
+            [
+                [
+                    re.compile(r"^IGNORE:"),
+                ],
+                "IGNORE: This should be ignored",
+                True,
+            ],
+            [
+                [re.compile(r"^IGNORE:"), re.compile(r"^IGNORE_TWO:")],
+                "IGNORE_TWO: This should also be ignored",
+                True,
+            ],
+            [
+                [
+                    re.compile(r"^IGNORE:"),
+                ],
+                "INFO: This should not be ignored",
+                False,
+            ],
+        ],
+    )
+    def test_ignores_patterns(
+        self,
+        patterns: List[re.Pattern[str]],
+        message: str,
+        should_be_ignored: bool,
+    ) -> None:
+        # GIVEN
+        record = logging.LogRecord("NAME", 0, "", 0, message, None, None)
+        formatter = ConditionalFormatter(ignore_patterns=patterns)
+
+        # WHEN
+        with patch.object(logging_mod.logging.Formatter, "format") as mock_format:
+            formatter.format(record)
+
+        # THEN
+        if should_be_ignored:
+            mock_format.assert_not_called()
+        else:
+            mock_format.assert_called_once_with(record)


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The adaptor runtime is currently printing `openjd_*` messages with log formatting enabled, meaning they are prefixed with the log level. This prevents these messages from being captured by OpenJD since they do not meet the spec of requiring the line start with `openjd_*`.

This manifests in two ways:
1. In "regular" mode (non-background/daemon), if an adaptor fails one of its `on_*` methods (e.g. `on_run`), we are currently emitting an `ERROR` level log message in the `AdaptorRunner` class ([code](https://github.com/xxyggoqtpcmcofkc/openjd-adaptor-runtime-for-python/blob/37d1ac3bc5c04b543f93de8abec3388c6e34a74b/src/openjd/adaptor_runtime/adaptors/_adaptor_runner.py#L86)). Our log formatter will print this with an `ERROR: ` prefix to the message.
2. In background/daemon mode, all adaptor stdout/stderr is emitted under the log level `ADAPTOR_OUTPUT`. Our log formatter will print this with an `ADAPTOR_OUTPUT: ` prefix to the message

### What was the solution? (How)
Added a conditional log formatter which does not apply formatting to any log messages that begin with `openjd_*`

### What is the impact of this change?
Any `openjd_*` message emitted by the adaptor runtime will no longer have log formatting applied to it, allowing it to be captured by OpenJD

### How was this change tested?
- Added unit test
- Manual E2E test with an example adaptor that always raises an "Oops" exception `on_run` (logs below)

### Was this change documented?
No

### Is this a breaking change?
No


### E2E testing logs

#### BEFORE - Regular mode

```
$ HelloWorldAdaptor
In HelloWorldAdaptor main
INFO: Applying user-level configuration: /home/jericht/.openjd/worker/adaptors/runtime/configuration.json
INFO: Applying user-level configuration: /home/jericht/.openjd/adaptors/HelloWorldAdaptor/HelloWorldAdaptor.json
INFO: Running command: /local/home/jericht/.local/share/hatch/env/virtual/openjd-adaptor-example/4ErhphO-/openjd-adaptor-example/bin/python /local/home/jericht/.local/share/hatch/env/virtual/openjd-adaptor-example/4ErhphO-/openjd-adaptor-example/lib/python3.9/site-packages/hello_world_adaptor/client.py /home/jericht/.openjd/adaptors/sockets/dcc/6775
 - - [17/Oct/2023 18:48:45] "GET /action HTTP/1.1" 200 -
STDOUT: Performing action: {"name": "print", "args": {"message": "on_start"}}
STDOUT: HelloWorld: on_start
ERROR: openjd_fail: Error encountered while running adaptor: Oops
ERROR: Error running the adaptor: Oops
 - - [17/Oct/2023 18:49:05] "GET /action HTTP/1.1" 200 -
STDOUT: Performing action: {"name": "close", "args": null}
STDOUT: closing
Entrypoint failed: Oops
```

#### AFTER - Regular Mode

```
$ HelloWorldAdaptor 
In HelloWorldAdaptor main
INFO: Applying user-level configuration: /home/jericht/.openjd/worker/adaptors/runtime/configuration.json
INFO: Applying user-level configuration: /home/jericht/.openjd/adaptors/HelloWorldAdaptor/HelloWorldAdaptor.json
INFO: Running command: /local/home/jericht/.local/share/hatch/env/virtual/openjd-adaptor-example/4ErhphO-/openjd-adaptor-example/bin/python /local/home/jericht/.local/share/hatch/env/virtual/openjd-adaptor-example/4ErhphO-/openjd-adaptor-example/lib/python3.9/site-packages/hello_world_adaptor/client.py /home/jericht/.openjd/adaptors/sockets/dcc/12498
 - - [17/Oct/2023 19:33:57] "GET /action HTTP/1.1" 200 -
STDOUT: Performing action: {"name": "print", "args": {"message": "on_start"}}
STDOUT: HelloWorld: on_start
openjd_fail: Error encountered while running adaptor: Oops
ERROR: Error running the adaptor: Oops
 - - [17/Oct/2023 19:34:17] "GET /action HTTP/1.1" 200 -
STDOUT: Performing action: {"name": "close", "args": null}
STDOUT: closing
Entrypoint failed: Oops
```

#### BEFORE - Background Mode

```
$ HelloWorldAdaptor daemon run --connection-file /tmp/HelloWorldAdaptor.json
In HelloWorldAdaptor main
INFO: Applying user-level configuration: /home/jericht/.openjd/worker/adaptors/runtime/configuration.json
INFO: Applying user-level configuration: /home/jericht/.openjd/adaptors/HelloWorldAdaptor/HelloWorldAdaptor.json
ADAPTOR_OUTPUT: 
ADAPTOR_OUTPUT: ERROR: openjd_fail: Error encountered while running adaptor: Oops
Entrypoint failed: 
ERROR: openjd_fail: Error encountered while running adaptor: Oops
```

#### AFTER - Background Mode

```
$ HelloWorldAdaptor daemon run --connection-file /tmp/HelloWorldAdaptor.json
In HelloWorldAdaptor main
INFO: Applying user-level configuration: /home/jericht/.openjd/worker/adaptors/runtime/configuration.json
INFO: Applying user-level configuration: /home/jericht/.openjd/adaptors/HelloWorldAdaptor/HelloWorldAdaptor.json
ADAPTOR_OUTPUT: 
openjd_fail: Error encountered while running adaptor: Oops
Entrypoint failed: 
openjd_fail: Error encountered while running adaptor: Oops
```

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*