### PR TITLE
refactor: Extract the adaptor handler logic to the AdaptorServerResponseGenerator.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ __pycache__/
 /dist
 _version.py
 .vscode
+.coverage
+.idea/

--- a/src/openjd/adaptor_runtime/application_ipc/_adaptor_server_response.py
+++ b/src/openjd/adaptor_runtime/application_ipc/_adaptor_server_response.py
@@ -1,0 +1,120 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+from __future__ import annotations
+
+import json
+import sys
+from http import HTTPStatus
+from time import sleep
+from typing import TYPE_CHECKING, Callable, Dict, Any, Optional
+from .._http import HTTPResponse
+
+if TYPE_CHECKING:  # pragma: no cover because pytest will think we should test for this.
+    from openjd.adaptor_runtime_client import Action
+    from ._adaptor_server import AdaptorServer
+
+
+class AdaptorServerResponseGenerator:
+    """
+    This class is used for generating responses for all requests to the Adaptor server.
+    Response methods follow format: `generate_{request_path}_{method}_response`
+    """
+
+    def __init__(
+        self,
+        server: AdaptorServer,
+        response_fn: Callable,
+        query_string_params: Dict[str, Any],
+    ) -> None:
+        """
+        Response generator
+
+        Args:
+            server: The server used for communication. For Linux, this will
+                be a AdaptorServer instance.
+            response_fn: The function used to return the result to the client.
+                For Linux, this will be an HTTPResponse instance.
+            query_string_params: The request parameters sent by the client.
+                For Linux, these will be extracted from the URL.
+        """
+        self.server = server
+        self.response_method = response_fn
+        self.query_string_params = query_string_params
+
+    def generate_path_mapping_get_response(self) -> HTTPResponse:
+        """
+        Handle GET request to /path_mapping path.
+
+        Returns:
+            HTTPResponse: A body and response code to send to the DCC Client
+        """
+
+        if "path" in self.query_string_params:
+            return self.response_method(
+                HTTPStatus.OK,
+                json.dumps(
+                    {"path": self.server.adaptor.map_path(self.query_string_params["path"][0])}
+                ),
+            )
+        else:
+            return self.response_method(HTTPStatus.BAD_REQUEST, "Missing path in query string.")
+
+    def generate_path_mapping_rules_get_response(self) -> HTTPResponse:
+        """
+        Handle GET request to /path_mapping_rules path.
+
+        Returns:
+            HTTPResponse: A body and response code to send to the DCC Client
+        """
+        return self.response_method(
+            HTTPStatus.OK,
+            json.dumps(
+                {
+                    "path_mapping_rules": [
+                        rule.to_dict() for rule in self.server.adaptor.path_mapping_rules
+                    ]
+                }
+            ),
+        )
+
+    def generate_action_get_response(self) -> HTTPResponse:
+        """
+        Handle GET request to /action path.
+
+        Returns:
+            HTTPResponse: A body and response code to send to the DCC Client
+        """
+        action = self._dequeue_action()
+
+        # We are going to wait until we have an action in the queue. This
+        # could happen between tasks.
+        while action is None:
+            sleep(0.01)
+            action = self._dequeue_action()
+
+        return self.response_method(HTTPStatus.OK, str(action))
+
+    def _dequeue_action(self) -> Optional[Action]:
+        """This function will dequeue the first action in the queue.
+
+        Returns:
+            Action: A tuple containing the next action structured:
+            ("action_name", { "args1": "val1", "args2": "val2" })
+
+            None: If the Actions Queue is empty.
+
+        Raises:
+            TypeError: If the server isn't an AdaptorServer.
+        """
+        # This condition shouldn't matter, because we have typehinted the server above.
+        # This is only here for type hinting (as is the return None below).
+        if hasattr(self, "server") and hasattr(self.server, "actions_queue"):
+            return self.server.actions_queue.dequeue_action()
+
+        print(
+            "ERROR: Could not retrieve the next action because the server or actions queue "
+            "wasn't set.",
+            file=sys.stderr,
+            flush=True,
+        )
+        return None

--- a/test/openjd/adaptor_runtime/unit/application_ipc/test_adaptor_http_request_handler.py
+++ b/test/openjd/adaptor_runtime/unit/application_ipc/test_adaptor_http_request_handler.py
@@ -129,7 +129,10 @@ class TestPathMappingRulesEndpoint:
 
 
 class TestActionEndpoint:
-    def test_get_returns_action(self):
+    @patch.object(
+        ActionEndpoint, "query_string_params", new_callable=PropertyMock, return_value="{}"
+    )
+    def test_get_returns_action(self, mock_qsp):
         # GIVEN
         mock_request_handler = MagicMock()
         mock_server = MagicMock(spec=_AdaptorServer)


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
During development of the Adaptor Server in Windows, I found there are lots of duplicate code, because the server will take the same action no matter in Linux or Windows.  

### What was the solution? (How)
Similar to previous PR: https://github.com/xxyggoqtpcmcofkc/openjd-adaptor-runtime-for-python/pull/20
Do some code refactoring in the Linux to extract the response logic to a new class `AdaptorServerResponseGenerator `,  so we can reuse those methods in both Windows and Linux. 
All integration tests are not changed, which means that this refactoring doesn't affect the behavior. I need to change some unit tests to mock `query_string_params` in some tests.

### What is the impact of this change?
It should not have any impacts in Linux.

### How was this change tested?
All tests are passed

### Was this change documented?
No

### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*