### PR TITLE
feat!: Add system config path for Windows, change path map to string 

### DIFF
--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -14,4 +14,5 @@ jobs:
     name: Code Quality
     uses: ./.github/workflows/reuse_python_build.yml
     secrets: inherit
+    if: always()
 

--- a/hatch.toml
+++ b/hatch.toml
@@ -6,7 +6,7 @@ pre-install-commands = [
 [envs.default.scripts]
 sync = "pip install -r requirements-testing.txt"
 test = "pytest --cov-config pyproject.toml {args:test}"
-test-windows = "pytest --cov-config pyproject.toml {args:test/openjd/adaptor_runtime/integ/background test/openjd/adaptor_runtime/integ/process} --cov-fail-under=48"
+test-windows = "pytest --cov-config pyproject.toml {args:test/openjd/adaptor_runtime/integ/background test/openjd/adaptor_runtime/integ/process test/openjd/adaptor_runtime/unit/adaptors/configuration/test_configuration_manager.py} --cov-fail-under=53"
 typing = "mypy {args:src test}"
 style = [
   "ruff {args:.}",

--- a/src/openjd/adaptor_runtime/_background/frontend_runner.py
+++ b/src/openjd/adaptor_runtime/_background/frontend_runner.py
@@ -119,7 +119,7 @@ class FrontendRunner:
         # Wait for backend process to create connection file
         try:
             # TODO: Need to investigate why more time is required in Windows
-            _wait_for_file(self._connection_file_path, timeout_s=5 if OSName.is_posix() else 10)
+            _wait_for_file(self._connection_file_path, timeout_s=5 if OSName.is_posix() else 15)
         except TimeoutError:
             _logger.error(
                 "Backend process failed to write connection file in time at: "

--- a/src/openjd/adaptor_runtime/_entrypoint.py
+++ b/src/openjd/adaptor_runtime/_entrypoint.py
@@ -57,24 +57,22 @@ _CLI_HELP_TEXT = {
 _DIR = os.path.dirname(os.path.realpath(__file__))
 # Keyword args to init the ConfigurationManager for the runtime.
 _ENV_CONFIG_PATH_PREFIX = "RUNTIME_CONFIG_PATH"
-_RUNTIME_CONFIG_PATHS: dict[Any, Any] = {
+_system_config_path_prefix = "/etc" if OSName.is_posix() else os.environ["PROGRAMDATA"]
+_system_config_path = os.path.abspath(
+    os.path.join(
+        _system_config_path_prefix,
+        "openjd",
+        "worker",
+        "adaptors",
+        "runtime",
+        "configuration.json",
+    )
+)
+
+_runtime_config_paths: dict[Any, Any] = {
     "schema_path": os.path.abspath(os.path.join(_DIR, "configuration.schema.json")),
     "default_config_path": os.path.abspath(os.path.join(_DIR, "configuration.json")),
-    "system_config_path_map": {
-        "Linux": os.path.abspath(
-            os.path.join(
-                os.path.sep,
-                "etc",
-                "openjd",
-                "worker",
-                "adaptors",
-                "runtime",
-                "configuration.json",
-            )
-        ),
-        # TODO: Replace this with a proper path
-        "Windows": r"C:/tmp/configuration.json",
-    },
+    "system_config_path": _system_config_path,
     "user_config_rel_path": os.path.join(
         ".openjd", "worker", "adaptors", "runtime", "configuration.json"
     ),
@@ -124,7 +122,7 @@ class EntryPoint:
         additional_config_path = os.environ.get(_ENV_CONFIG_PATH_PREFIX)
         self.config_manager = ConfigurationManager(
             config_cls=RuntimeConfiguration,
-            **_RUNTIME_CONFIG_PATHS,
+            **_runtime_config_paths,
             additional_config_paths=[additional_config_path] if additional_config_path else [],
         )
         try:

--- a/src/openjd/adaptor_runtime/adaptors/configuration/_configuration_manager.py
+++ b/src/openjd/adaptor_runtime/adaptors/configuration/_configuration_manager.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import json
 import logging
 import os
-import posixpath
 import stat
 from typing import Generic, List, Type, TypeVar
 
@@ -51,26 +50,21 @@ def create_adaptor_configuration_manager(
     elif isinstance(schema_path, list):
         schema_paths.extend(schema_path)
 
-    system_config_path_map = {
-        "Linux": posixpath.abspath(
-            posixpath.join(
-                posixpath.sep,
-                "etc",
-                "openjd",
-                "adaptors",
-                adaptor_name,
-                f"{adaptor_name}.json",
-            )
-        ),
-        # TODO: Confirm the windows path format
-        "Windows": f"C:/tmp/{adaptor_name}/{adaptor_name}.json",
-    }
+    system_config_path_prefix = "/etc" if OSName.is_posix() else os.environ["PROGRAMDATA"]
+    system_config_path = os.path.join(
+        system_config_path_prefix,
+        "openjd",
+        "adaptors",
+        adaptor_name,
+        f"{adaptor_name}.json",
+    )
+
     user_config_rel_path = os.path.join(".openjd", "adaptors", adaptor_name, f"{adaptor_name}.json")
 
     return ConfigurationManager(
         config_cls=config_cls,
         default_config_path=default_config_path,
-        system_config_path_map=system_config_path_map,
+        system_config_path=system_config_path,
         user_config_rel_path=user_config_rel_path,
         schema_path=schema_paths,
         additional_config_paths=additional_config_paths,
@@ -121,7 +115,7 @@ class ConfigurationManager(Generic[_ConfigType]):
         *,
         config_cls: Type[_ConfigType],
         default_config_path: str,
-        system_config_path_map: dict,
+        system_config_path: str,
         user_config_rel_path: str,
         schema_path: str | List[str] | None = None,
         additional_config_paths: list[str] = [],
@@ -132,8 +126,7 @@ class ConfigurationManager(Generic[_ConfigType]):
         Args:
             config_cls (Type[T]): The Configuration class that this class manages.
             default_config_path (str): The path to the default configuration JSON file.
-            system_config_path_map (dict): A dictionary containing a mapping of OS names to system
-            configuration file path.
+            system_config_path (str): The path to the system config file.
             user_config_rel_path (str): The path to the user configuration file relative to the
             user's home directory.
             schema_path (str, List[str], Optional): The path(s) to the JSON Schema file to use.
@@ -145,7 +138,7 @@ class ConfigurationManager(Generic[_ConfigType]):
         self._config_cls = config_cls
         self._schema_path = schema_path
         self._default_config_path = default_config_path
-        self._system_config_path_map = system_config_path_map
+        self._system_config_path = system_config_path
         self._user_config_rel_path = user_config_rel_path
         self._additional_config_paths = additional_config_paths
 
@@ -166,20 +159,9 @@ class ConfigurationManager(Generic[_ConfigType]):
         """
         Gets the system-level configuration file path.
 
-        Raises:
-            NotImplementedError: Raised when no mapping exists for the system config path on
-            the current system/OS.
         """
-        try:
-            system = OSName()
-        except ValueError:  # Can happen on unsupported platforms like Java
-            raise NotImplementedError()
 
-        path = self._system_config_path_map.get(system, None)
-        if path is None:
-            raise NotImplementedError()
-
-        return path
+        return self._system_config_path
 
     def get_system_config(self) -> _ConfigType | None:
         """
@@ -250,7 +232,7 @@ class ConfigurationManager(Generic[_ConfigType]):
 
         system_config = self.get_system_config()
         if system_config:
-            _logger.info(f"Applying system-level configuration: {self.get_system_config_path()}")
+            _logger.info(f"Applying system-level configuration: {self._system_config_path}")
             old_config = config
             config = config.override(system_config)
             log_diffs(config, old_config)

--- a/test/openjd/adaptor_runtime/conftest.py
+++ b/test/openjd/adaptor_runtime/conftest.py
@@ -19,6 +19,13 @@ def pytest_collection_modifyitems(items):
                 "integ",
                 "test_integration_entrypoint.py",
             ),
+            os.path.join(
+                os.path.abspath(os.path.dirname(__file__)),
+                "unit",
+                "adaptors",
+                "configuration",
+                "test_configuration_manager.py",
+            ),
         ]
         skip_marker = pytest.mark.skip(reason="Skipping tests on Windows")
         for item in items:

--- a/test/openjd/adaptor_runtime/integ/adaptors/configuration/test_configuration_manager.py
+++ b/test/openjd/adaptor_runtime/integ/adaptors/configuration/test_configuration_manager.py
@@ -44,7 +44,7 @@ class TestConfigurationManagerLinux:
             manager = ConfigurationManager(
                 config_cls=Configuration,
                 schema_path=json_schema_file.name,
-                system_config_path_map={"Linux": config_file.name},
+                system_config_path=config_file.name,
                 # These fields can be empty since they will not be used in this test
                 default_config_path="",
                 user_config_rel_path="",
@@ -82,7 +82,7 @@ class TestConfigurationManagerLinux:
                 config_cls=Configuration,
                 schema_path=json_schema_file.name,
                 default_config_path=default_config_file.name,
-                system_config_path_map={"Linux": system_config_file.name},
+                system_config_path=system_config_file.name,
                 user_config_rel_path=os.path.relpath(
                     user_config_file.name,
                     start=os.path.expanduser("~"),

--- a/test/openjd/adaptor_runtime/integ/background/test_background_mode.py
+++ b/test/openjd/adaptor_runtime/integ/background/test_background_mode.py
@@ -62,7 +62,7 @@ class TestDaemonMode:
     ) -> Generator[tuple[FrontendRunner, psutil.Process], None, None]:
         caplog.set_level(0)
         # TODO: Investigate why we need more time in Windows.
-        frontend = FrontendRunner(connection_file_path, timeout_s=5.0 if OSName.is_posix() else 10)
+        frontend = FrontendRunner(connection_file_path, timeout_s=5.0 if OSName.is_posix() else 15)
         frontend.init(sys.modules[SampleAdaptor.__module__])
         conn_settings = _load_connection_settings(connection_file_path)
 

--- a/test/openjd/adaptor_runtime/unit/adaptors/configuration/stubs.py
+++ b/test/openjd/adaptor_runtime/unit/adaptors/configuration/stubs.py
@@ -58,7 +58,7 @@ class ConfigurationManagerMock(ConfigurationManager):
         *,
         schema_path="",
         default_config_path="",
-        system_config_path_map={},
+        system_config_path="",
         user_config_rel_path="",
         additional_config_paths=[],
     ) -> None:
@@ -66,7 +66,7 @@ class ConfigurationManagerMock(ConfigurationManager):
             config_cls=Configuration,
             schema_path=schema_path,
             default_config_path=default_config_path,
-            system_config_path_map=system_config_path_map,
+            system_config_path=system_config_path,
             user_config_rel_path=user_config_rel_path,
             additional_config_paths=additional_config_paths,
         )


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The system config path for Windows needs to be implemented.

### What was the solution? (How)
The Posix implementation of the configuration manager looks for the system config in `/etc/openjd/adaptors`. On Windows, system-level application data is typically stored in [ProgramData](https://learn.microsoft.com/en-us/windows-hardware/customize/desktop/unattend/microsoft-windows-shell-setup-folderlocations-programdata). While this is *usually* located at `C:\ProgramData`, the location can vary depending on system configuration. Therefore, we need to get this path from the `PROGRAMDATA` environment variable.

Because we're getting the Windows path from an environment variable, we will get an error when constructing the system config path map on Posix because the environment variable will not be set on such systems. Therefore, we have 2 options:
1. Continue to use a system config path map, but on Posix systems set the Windows system config path to a sensible default which may not be accurate for all Windows systems.
2. Change the `ConfigurationManager` to take a string `system_config_path` instead of `system_config_path_map`, and let the caller determine what path to pass to the constructor based on the OS. 

This PR implements option 2 because a `ConfigurationManager` on Posix does not need to know where the system config path *may* be on a Windows system. 

### What is the impact of this change?
System config can be loaded on Windows.

### How was this change tested?
Unit tests pass

### Was this change documented?
No

### Is this a breaking change?
Yes. `ConfigurationManager` now takes a string `system_config_path` in lieu of the `system_config_path_map` dict.

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*