### PR TITLE
refactor: Replace cancel queue with a shutdown event.

### DIFF
--- a/src/openjd/adaptor_runtime/_background/http_server.py
+++ b/src/openjd/adaptor_runtime/_background/http_server.py
@@ -6,7 +6,7 @@ import json
 import logging
 import socketserver
 from http import HTTPStatus
-from queue import Queue
+from threading import Event
 from typing import Callable
 from .._osname import OSName
 from .server_response import ServerResponseGenerator, AsyncFutureRunner
@@ -36,14 +36,14 @@ class BackgroundHTTPServer(UnixStreamServer):
         self,
         socket_path: str,
         adaptor_runner: AdaptorRunner,
-        cancel_queue: Queue,
+        shutdown_event: Event,
         *,
         log_buffer: LogBuffer | None = None,
         bind_and_activate: bool = True,
     ) -> None:  # pragma: no cover
         super().__init__(socket_path, BackgroundRequestHandler, bind_and_activate)  # type: ignore
         self._adaptor_runner = adaptor_runner
-        self._cancel_queue = cancel_queue
+        self._shutdown_event = shutdown_event
         self._future_runner = AsyncFutureRunner()
         self._log_buffer = log_buffer
 

--- a/src/openjd/adaptor_runtime/_background/server_response.py
+++ b/src/openjd/adaptor_runtime/_background/server_response.py
@@ -163,7 +163,7 @@ class ServerResponseGenerator:
             Linux: return HTTPResponse.
         """
 
-        self.server._cancel_queue.put(True)
+        self.server._shutdown_event.set()
         return self.response_method(HTTPStatus.OK)
 
     def generate_run_put_response(self) -> HTTPResponse:

--- a/test/openjd/adaptor_runtime/unit/background/test_backend_runner.py
+++ b/test/openjd/adaptor_runtime/unit/background/test_backend_runner.py
@@ -39,12 +39,12 @@ class TestBackendRunner:
 
     @patch.object(backend_runner.json, "dump")
     @patch.object(backend_runner.os, "remove")
-    @patch.object(backend_runner, "Queue")
+    @patch.object(backend_runner, "Event")
     @patch.object(backend_runner, "Thread")
     def test_run(
         self,
         mock_thread: MagicMock,
-        mock_queue: MagicMock,
+        mock_event: MagicMock,
         mock_os_remove: MagicMock,
         mock_json_dump: MagicMock,
         mock_server_cls: MagicMock,
@@ -74,7 +74,7 @@ class TestBackendRunner:
         mock_server_cls.assert_called_once_with(
             socket_path,
             adaptor_runner,
-            mock_queue.return_value,
+            mock_event.return_value,
             log_buffer=None,
         )
         mock_thread.assert_called_once()
@@ -112,12 +112,12 @@ class TestBackendRunner:
 
     @patch.object(backend_runner, "secure_open")
     @patch.object(backend_runner.os, "remove")
-    @patch.object(backend_runner, "Queue")
+    @patch.object(backend_runner, "Event")
     @patch.object(backend_runner, "Thread")
     def test_run_raises_when_writing_connection_file_fails(
         self,
         mock_thread: MagicMock,
-        mock_queue: MagicMock,
+        mock_event: MagicMock,
         mock_os_remove: MagicMock,
         open_mock: MagicMock,
         socket_path: str,
@@ -137,7 +137,7 @@ class TestBackendRunner:
 
         # THEN
         assert raised_err.value is err
-        mock_queue.return_value.put.assert_called_once_with(True)
+        mock_event.return_value.set.assert_called_once()
         assert caplog.messages == [
             "Running in background daemon mode.",
             f"Listening on {socket_path}",

--- a/test/openjd/adaptor_runtime/unit/background/test_http_server.py
+++ b/test/openjd/adaptor_runtime/unit/background/test_http_server.py
@@ -4,7 +4,7 @@ import json
 import os
 import socketserver
 from http import HTTPStatus
-from queue import Queue
+from threading import Event
 from unittest.mock import MagicMock, PropertyMock, patch
 
 import pytest
@@ -554,8 +554,8 @@ class TestShutdownHandler:
         # GIVEN
         mock_request_handler = MagicMock()
         mock_server = MagicMock(spec=BackgroundHTTPServer)
-        mock_cancel_queue = MagicMock(spec=Queue)
-        mock_server._cancel_queue = mock_cancel_queue
+        mock_shutdown_event = MagicMock(spec=Event)
+        mock_server._shutdown_event = mock_shutdown_event
         mock_request_handler.server = mock_server
         mock_request_handler.headers = {"Content-Length": 0}
         mock_request_handler.path = ""
@@ -565,7 +565,7 @@ class TestShutdownHandler:
         response = handler.put()
 
         # THEN
-        mock_cancel_queue.put.assert_called_once_with(True)
+        mock_shutdown_event.set.assert_called_once()
         assert response.status == HTTPStatus.OK
         assert response.body is None
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Currently, we are using a queue for communicating between threads. This is not common in python. We should use `threading.event` to do it.

### What was the solution? (How)
Create a shutdown_event to replace the `cancel_queue` and update the shutdown logic.

### What is the impact of this change?
This should not change any behaviors. 

### How was this change tested?
All tests are passed.

### Was this change documented?
No.

### Is this a breaking change?
No.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*