### PR TITLE
feat!: Use Named Pipe to implement the Adaptor Server in Windows.

### DIFF
--- a/hatch.toml
+++ b/hatch.toml
@@ -6,7 +6,7 @@ pre-install-commands = [
 [envs.default.scripts]
 sync = "pip install -r requirements-testing.txt"
 test = "pytest --cov-config pyproject.toml {args:test}"
-test-windows = "pytest --cov-config pyproject.toml {args:test/openjd/adaptor_runtime/integ/background test/openjd/adaptor_runtime/integ/process test/openjd/adaptor_runtime/unit/adaptors/configuration/test_configuration_manager.py} --cov-fail-under=53"
+test-windows = "pytest --cov-config pyproject.toml {args:test/openjd/adaptor_runtime/integ/background test/openjd/adaptor_runtime/integ/process test/openjd/adaptor_runtime/unit/adaptors/configuration/test_configuration_manager.py} --cov-fail-under=50"
 typing = "mypy {args:src test}"
 style = [
   "ruff {args:.}",

--- a/src/openjd/adaptor_runtime/_named_pipe/named_pipe_server.py
+++ b/src/openjd/adaptor_runtime/_named_pipe/named_pipe_server.py
@@ -13,6 +13,10 @@ from openjd.adaptor_runtime._background.server_config import (
     NAMED_PIPE_BUFFER_SIZE,
     DEFAULT_NAMED_PIPE_TIMEOUT_MILLISECONDS,
 )
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from openjd.adaptor_runtime._named_pipe import ResourceRequestHandler
 from openjd.adaptor_runtime._osname import OSName
 
 import win32pipe
@@ -157,7 +161,9 @@ class NamedPipeServer(ABC):
             threading.Thread(target=self.request_handler(self, pipe_handle).instance_thread).start()
 
     @abstractmethod
-    def request_handler(self, server: NamedPipeServer, pipe_handle: HANDLE):
+    def request_handler(
+        self, server: NamedPipeServer, pipe_handle: HANDLE
+    ) -> "ResourceRequestHandler":
         return NotImplemented
 
     def shutdown(self) -> None:

--- a/src/openjd/adaptor_runtime/application_ipc/__init__.py
+++ b/src/openjd/adaptor_runtime/application_ipc/__init__.py
@@ -5,7 +5,7 @@ from .._osname import OSName
 
 if OSName.is_posix():
     from ._adaptor_server import AdaptorServer
-
-    __all__ = ["ActionsQueue", "AdaptorServer"]
 else:
-    __all__ = ["ActionsQueue"]
+    from ._win_adaptor_server import WinAdaptorServer as AdaptorServer  # type: ignore
+
+__all__ = ["ActionsQueue", "AdaptorServer"]

--- a/src/openjd/adaptor_runtime/application_ipc/_adaptor_server.py
+++ b/src/openjd/adaptor_runtime/application_ipc/_adaptor_server.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import os
+import warnings
+
 from .._osname import OSName
 
 if OSName.is_windows():
@@ -19,6 +21,10 @@ from ._http_request_handler import AdaptorHTTPRequestHandler
 if TYPE_CHECKING:  # pragma: no cover because pytest will think we should test for this.
     from ..adaptors import BaseAdaptor
     from ._actions_queue import ActionsQueue
+
+SOCKET_PATH_DUPLICATED_MESSAGE = (
+    "The 'socket_path' parameter is deprecated; use 'server_path' instead"
+)
 
 
 class AdaptorServer(UnixStreamServer):
@@ -39,7 +45,17 @@ class AdaptorServer(UnixStreamServer):
 
         self.actions_queue = actions_queue
         self.adaptor = adaptor
-        self.socket_path = socket_path
+        self.server_path = socket_path
+
+    @property
+    def socket_path(self):
+        warnings.warn(SOCKET_PATH_DUPLICATED_MESSAGE, DeprecationWarning)
+        return self.server_path
+
+    @socket_path.setter
+    def socket_path(self, value):
+        warnings.warn(SOCKET_PATH_DUPLICATED_MESSAGE, DeprecationWarning)
+        self.server_path = value
 
     def shutdown(self) -> None:  # pragma: no cover
         super().shutdown()

--- a/src/openjd/adaptor_runtime/application_ipc/_adaptor_server_response.py
+++ b/src/openjd/adaptor_runtime/application_ipc/_adaptor_server_response.py
@@ -6,12 +6,14 @@ import json
 import sys
 from http import HTTPStatus
 from time import sleep
-from typing import TYPE_CHECKING, Callable, Dict, Any, Optional
+from typing import TYPE_CHECKING, Callable, Dict, Any, Optional, Union
+
 from .._http import HTTPResponse
 
 if TYPE_CHECKING:  # pragma: no cover because pytest will think we should test for this.
     from openjd.adaptor_runtime_client import Action
     from ._adaptor_server import AdaptorServer
+    from ._win_adaptor_server import WinAdaptorServer
 
 
 class AdaptorServerResponseGenerator:
@@ -22,7 +24,7 @@ class AdaptorServerResponseGenerator:
 
     def __init__(
         self,
-        server: AdaptorServer,
+        server: Union[AdaptorServer, WinAdaptorServer],
         response_fn: Callable,
         query_string_params: Dict[str, Any],
     ) -> None:

--- a/src/openjd/adaptor_runtime/application_ipc/_named_pipe_request_handler.py
+++ b/src/openjd/adaptor_runtime/application_ipc/_named_pipe_request_handler.py
@@ -1,0 +1,70 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+import json
+from http import HTTPStatus
+from typing import TYPE_CHECKING, cast
+
+from ._adaptor_server_response import AdaptorServerResponseGenerator
+from .._named_pipe import ResourceRequestHandler
+
+if TYPE_CHECKING:  # pragma: no cover because pytest will think we should test for this.
+    from ._win_adaptor_server import WinAdaptorServer
+
+from pywintypes import HANDLE
+import logging
+
+_logger = logging.getLogger(__name__)
+
+
+class WinAdaptorServerResourceRequestHandler(ResourceRequestHandler):
+    """
+    A handler for managing requests sent to a NamedPipe instance within a Windows environment.
+
+    This class handles incoming requests, processes them, and sends back appropriate responses.
+    It is designed to work in conjunction with a WinAdaptorServer that manages the
+    lifecycle of the NamedPipe server and other associated resources.
+    """
+
+    def __init__(self, server: "WinAdaptorServer", pipe_handle: HANDLE):
+        """
+        Initializes the WinBackgroundResourceRequestHandler with a server and pipe handle.
+
+        Args:
+            server(WinAdaptorServer): The server instance that created this handler.
+                It is responsible for managing the lifecycle of the NamedPipe server and other resources.
+            pipe_handle(pipe_handle): The handle to the NamedPipe instance created and managed by the server.
+        """
+        super().__init__(server, pipe_handle)
+
+    def handle_request(self, data: str):
+        """
+        Processes an incoming request and routes it to the correct response handler based on the method
+        and request path.
+
+        Args:
+            data: A string containing the message sent from the client.
+        """
+        request_dict = json.loads(data)
+        # Ignore the leading `/`
+        path = request_dict["path"][1:]
+        method: str = request_dict["method"]
+
+        if "params" in request_dict and request_dict["params"] != "null":
+            query_string_params = json.loads(request_dict["params"])
+        else:
+            query_string_params = {}
+
+        server_operation = AdaptorServerResponseGenerator(
+            cast("WinAdaptorServer", self.server), self.send_response, query_string_params
+        )
+        try:
+            method_name = f"generate_{path}_{method.lower()}_response"
+            getattr(server_operation, method_name)()
+        except Exception as e:
+            error_message = (
+                f"Error encountered in request handling. "
+                f"Path: '{path}', Method: '{method}', Error: '{str(e)}'"
+            )
+            _logger.error(error_message)
+            self.send_response(HTTPStatus.BAD_REQUEST, error_message)
+            raise

--- a/src/openjd/adaptor_runtime/application_ipc/_win_adaptor_server.py
+++ b/src/openjd/adaptor_runtime/application_ipc/_win_adaptor_server.py
@@ -1,0 +1,59 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+from __future__ import annotations
+
+import os
+from threading import Event
+from pywintypes import HANDLE
+
+from ._named_pipe_request_handler import WinAdaptorServerResourceRequestHandler
+from .._named_pipe import ResourceRequestHandler
+from .._named_pipe.named_pipe_server import NamedPipeServer
+
+
+from typing import TYPE_CHECKING, cast
+
+if TYPE_CHECKING:  # pragma: no cover because pytest will think we should test for this.
+    from ..adaptors import BaseAdaptor
+    from ._actions_queue import ActionsQueue
+
+
+class WinAdaptorServer(NamedPipeServer):
+    """
+    This is the Adaptor server which will be passed the populated ActionsQueue from the Adaptor.
+    """
+
+    actions_queue: ActionsQueue
+    adaptor: BaseAdaptor
+
+    def __init__(self, actions_queue: ActionsQueue, adaptor: BaseAdaptor) -> None:
+        """
+        Adaptor Server class in Windows.
+
+        Args:
+            actions_queue: A queue used for storing all actions sent by the client.
+            adaptor: The adaptor class used for reacting to the request.
+        """
+        # TODO: Do a code refactoring to generate the namedpipe server path
+        #  Need to check if the pipe name is used and the max length.
+        self.server_path = rf"\\.\pipe\AdaptorServerNamedPipe_{str(os.getpid())}"
+        shutdown_event = Event()
+        super().__init__(self.server_path, shutdown_event)
+
+        self.actions_queue = actions_queue
+        self.adaptor = adaptor
+
+    def request_handler(
+        self, server: NamedPipeServer, pipe_handle: HANDLE
+    ) -> ResourceRequestHandler:
+        """
+        Initializes the handler for handling the request from the client.
+
+        Args:
+            server: The NamedPipeServer that maintains the lifecycle of all resources.
+            pipe_handle: The pip handle used for communication between client and server.
+
+        Returns:
+            ResourceRequestHandler: The Handler that handle the request.
+        """
+        return WinAdaptorServerResourceRequestHandler(cast("WinAdaptorServer", server), pipe_handle)

--- a/src/openjd/adaptor_runtime_client/__init__.py
+++ b/src/openjd/adaptor_runtime_client/__init__.py
@@ -1,14 +1,20 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 from .action import Action
-from .posix_client_interface import (
-    HTTPClientInterface,
+from .base_client_interface import (
+    PathMappingRule,
 )
+from ..adaptor_runtime._osname import OSName
 
-from .base_client_interface import PathMappingRule
+if OSName.is_posix():
+    from .posix_client_interface import HTTPClientInterface as ClientInterface
 
-__all__ = [
-    "Action",
-    "HTTPClientInterface",
-    "PathMappingRule",
-]
+    # This is just for backward compatible
+    from .posix_client_interface import HTTPClientInterface
+
+    __all__ = ["Action", "PathMappingRule", "HTTPClientInterface", "ClientInterface"]
+
+else:
+    from .win_client_interface import WinClientInterface as ClientInterface  # type: ignore
+
+    __all__ = ["Action", "PathMappingRule", "ClientInterface"]

--- a/src/openjd/adaptor_runtime_client/base_client_interface.py
+++ b/src/openjd/adaptor_runtime_client/base_client_interface.py
@@ -47,11 +47,18 @@ class Response:
 
 class BaseClientInterface(_ABC):
     actions: _Dict[str, _Callable[..., None]]
+    server_path: str
 
-    def __init__(self) -> None:
+    def __init__(self, server_path: str) -> None:
         """
-        When the client is created, we need the port number to connect to the server.
+        When the client is created, we need the server address to connect to the server.
+
+        Args:
+            server_path(str): Server address used for connection.
+                In linux, this will be used for socket path.
+                In Windows, this will be used for pipe name.
         """
+        self.server_path = server_path
         self.actions = {
             "close": self.close,
         }

--- a/src/openjd/adaptor_runtime_client/win_client_interface.py
+++ b/src/openjd/adaptor_runtime_client/win_client_interface.py
@@ -1,0 +1,48 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+from __future__ import annotations
+
+from .base_client_interface import Response as _Response
+import http.client
+
+
+from .base_client_interface import BaseClientInterface
+from ..adaptor_runtime._named_pipe.named_pipe_helper import NamedPipeHelper
+
+_DEFAULT_TIMEOUT_IN_SECONDS = 15
+
+
+class WinClientInterface(BaseClientInterface):
+    def __init__(self, server_path: str) -> None:
+        """When the client is created, we need the port number to connect to the server.
+
+        Args:
+            server_path (str): Used as pipe name in Named Pipe Server.
+        """
+        # TODO: Add a logic to handle CTRL-Break signal here
+        super().__init__(server_path)
+
+    def _send_request(
+        self,
+        method: str,
+        path: str,
+        *,
+        query_string_params: dict | None = None,
+    ):
+        if query_string_params:
+            # This is used for aligning to the Linux's behavior in order to reuse the code in handler.
+            # In linux, query string params will always be put in a list.
+            query_string_params = {key: [value] for key, value in query_string_params.items()}
+        json_result = NamedPipeHelper.send_named_pipe_request(
+            self.server_path,
+            _DEFAULT_TIMEOUT_IN_SECONDS,
+            method,
+            path,
+            params=query_string_params,
+        )
+        return _Response(
+            json_result["status"],
+            json_result["body"],
+            http.client.responses[json_result["status"]],
+            len(json_result["body"]),
+        )

--- a/test/openjd/adaptor_runtime/conftest.py
+++ b/test/openjd/adaptor_runtime/conftest.py
@@ -14,6 +14,7 @@ def pytest_collection_modifyitems(items):
         do_not_skip_paths = [
             os.path.join(os.path.abspath(os.path.dirname(__file__)), "integ", "background"),
             os.path.join(os.path.abspath(os.path.dirname(__file__)), "integ", "process"),
+            os.path.join(os.path.abspath(os.path.dirname(__file__)), "integ", "application_ipc"),
             os.path.join(
                 os.path.abspath(os.path.dirname(__file__)),
                 "integ",

--- a/test/openjd/adaptor_runtime/integ/application_ipc/fake_app_client.py
+++ b/test/openjd/adaptor_runtime/integ/application_ipc/fake_app_client.py
@@ -6,10 +6,10 @@ from typing import Any as _Any
 from typing import Dict as _Dict
 from typing import Optional as _Optional
 
-from openjd.adaptor_runtime_client import HTTPClientInterface as _HTTPClientInterface
+from openjd.adaptor_runtime_client import ClientInterface as _ClientInterface
 
 
-class FakeAppClient(_HTTPClientInterface):
+class FakeAppClient(_ClientInterface):
     def __init__(self, socket_path: str) -> None:
         super().__init__(socket_path)
         self.actions.update({"hello_world": self.hello_world})


### PR DESCRIPTION
BREAKING CHANGE:  Add `server_address` to the `__init__` of `BaseClientInterface`

### What was the problem/requirement? (What/Why)
Adaptor Server is not implemented in the Windows.

### What was the solution? (How)
Use Named Pipe to implement it 

### What is the impact of this change?
AdaptorServer is implemented in Windows.

### How was this change tested?
Run the integration test.

### Was this change documented?
No

### Is this a breaking change?
Yes, Add `server_address` to the `__init__` of `BaseClientInterface`


----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*