### PR TITLE
feat: Enable the linter in Windows GithubCI

### DIFF
--- a/.github/workflows/reuse_python_build.yml
+++ b/.github/workflows/reuse_python_build.yml
@@ -66,7 +66,6 @@ jobs:
       run: pip install --upgrade -r requirements-development.txt
 
     - name: Run Linting
-      if: ${{ matrix.os == 'ubuntu-latest'}}
       run: hatch run lint
 
     - name: Run Tests Linux

--- a/src/openjd/adaptor_runtime/_background/frontend_runner.py
+++ b/src/openjd/adaptor_runtime/_background/frontend_runner.py
@@ -367,7 +367,7 @@ class UnixHTTPConnection(http_client.HTTPConnection):
         super(UnixHTTPConnection, self).__init__("localhost", **kwargs)
 
     def connect(self):
-        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)  # type: ignore[attr-defined]
         sock.settimeout(self.timeout)
         sock.connect(self.socket_path)
         self.sock = sock

--- a/src/openjd/adaptor_runtime/_http/request_handler.py
+++ b/src/openjd/adaptor_runtime/_http/request_handler.py
@@ -114,7 +114,7 @@ class RequestHandler(server.BaseHTTPRequestHandler):
         # Verify we have a UNIX socket.
         if not (
             isinstance(self.connection, socket.socket)
-            and self.connection.family == socket.AddressFamily.AF_UNIX
+            and self.connection.family == socket.AddressFamily.AF_UNIX  # type: ignore[attr-defined]
         ):
             raise UnsupportedPlatformException(
                 "Failed to handle request because it was not made through a UNIX socket"
@@ -122,14 +122,14 @@ class RequestHandler(server.BaseHTTPRequestHandler):
 
         # Get the credentials of the peer process
         cred_buffer = self.connection.getsockopt(
-            socket.SOL_SOCKET,
-            socket.SO_PEERCRED,
-            socket.CMSG_SPACE(ctypes.sizeof(UCred)),
+            socket.SOL_SOCKET,  # type: ignore[attr-defined]
+            socket.SO_PEERCRED,  # type: ignore[attr-defined]
+            socket.CMSG_SPACE(ctypes.sizeof(UCred)),  # type: ignore[attr-defined]
         )
         peer_cred = UCred.from_buffer_copy(cred_buffer)
 
         # Only allow connections from a process running as the same user
-        return peer_cred.uid == os.getuid()
+        return peer_cred.uid == os.getuid()  # type: ignore[attr-defined]
 
 
 class UCred(ctypes.Structure):

--- a/src/openjd/adaptor_runtime_client/connection.py
+++ b/src/openjd/adaptor_runtime_client/connection.py
@@ -39,7 +39,7 @@ class UnixHTTPConnection(_HTTPConnection):  # pragma: no cover
         super(UnixHTTPConnection, self).__init__(host, **kwargs)
 
     def connect(self):
-        sock = _socket.socket(_socket.AF_UNIX, _socket.SOCK_STREAM)
+        sock = _socket.socket(_socket.AF_UNIX, _socket.SOCK_STREAM)  # type: ignore[attr-defined]
         sock.settimeout(self.timeout)
         sock.connect(self.host)
         self.sock = sock
@@ -55,7 +55,7 @@ class UnixHTTPConnection(_HTTPConnection):  # pragma: no cover
         # Verify we have a UNIX socket.
         if not (
             isinstance(self.sock, _socket.socket)
-            and self.sock.family == _socket.AddressFamily.AF_UNIX
+            and self.sock.family == _socket.AddressFamily.AF_UNIX  # type: ignore[attr-defined]
         ):
             raise NotImplementedError(
                 "Failed to handle request because it was not made through a UNIX socket"
@@ -63,11 +63,11 @@ class UnixHTTPConnection(_HTTPConnection):  # pragma: no cover
 
         # Get the credentials of the peer process
         cred_buffer = self.sock.getsockopt(
-            _socket.SOL_SOCKET,
-            _socket.SO_PEERCRED,
-            _socket.CMSG_SPACE(_ctypes.sizeof(UCred)),
+            _socket.SOL_SOCKET,  # type: ignore[attr-defined]
+            _socket.SO_PEERCRED,  # type: ignore[attr-defined]
+            _socket.CMSG_SPACE(_ctypes.sizeof(UCred)),  # type: ignore[attr-defined]
         )
         peer_cred = UCred.from_buffer_copy(cred_buffer)
 
         # Only allow connections from a process running as the same user
-        return peer_cred.uid == _os.getuid()
+        return peer_cred.uid == _os.getuid()  # type: ignore[attr-defined]

--- a/test/openjd/adaptor_runtime/unit/http/test_request_handler.py
+++ b/test/openjd/adaptor_runtime/unit/http/test_request_handler.py
@@ -145,7 +145,7 @@ class TestAuthentication:
         @pytest.fixture
         def mock_handler(self) -> MagicMock:
             mock_socket = MagicMock(spec=socket.socket)
-            mock_socket.family = socket.AddressFamily.AF_UNIX
+            mock_socket.family = socket.AddressFamily.AF_UNIX  # type: ignore[attr-defined]
 
             mock_handler = MagicMock(spec=RequestHandler)
             mock_handler.connection = mock_socket


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Linter is disabled in the Windows Github CI, and we need to enable it.

### What was the solution? (How)
Add `# type: ignore` to ignore some properties only exist in Linux to ensure linter can pass in Windows.

### What is the impact of this change?
We can run `python -m hatch run lint` locally and in Github CI.

### How was this change tested?
`python -m hatch run lint` can pass in my local.

### Was this change documented?
No

### Is this a breaking change?
NO

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*