### PR TITLE
test: Conditionally omit OS-specific code from coverage check

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,6 +117,7 @@ addopts = [
 [tool.coverage.run]
 branch = true
 parallel = true
+plugins = ["coverage_conditional_plugin"]
 
 
 [tool.coverage.paths]
@@ -124,6 +125,29 @@ source = [
   "src/"
 ]
 
+[tool.coverage.coverage_conditional_plugin.omit]
+# Source files to exclude from coverage on Posix
+"sys_platform != 'win32'" = [
+  "src/openjd/adaptor_runtime/_background/backend_named_pipe_server.py",
+  "src/openjd/adaptor_runtime/_background/background_named_pipe_request_handler.py",
+  "src/openjd/adaptor_runtime/_named_pipe/*.py",
+  "src/openjd/adaptor_runtime/application_ipc/_win_adaptor_server.py",
+  "src/openjd/adaptor_runtime/application_ipc/_named_pipe_request_handler.py",
+  "src/openjd/adaptor_runtime_client/win_client_interface.py"
+]
+# Source files to exclude from coverage on Windows
+"sys_platform == 'win32'" = [
+  "src/openjd/adaptor_runtime/_background/http_server.py",
+  "src/openjd/adaptor_runtime/application_ipc/_adaptor_server.py",
+  "src/openjd/adaptor_runtime/application_ipc/_http_request_handler.py",
+  "src/openjd/adaptor_runtime_client/connection.py",
+  "src/openjd/adaptor_runtime_client/posix_client_interface.py",
+]
+
+[tool.coverage.coverage_conditional_plugin.rules]
+is-windows = "sys_platform == 'win32'"
+is-posix = "sys_platform != 'win32'"
+
 [tool.coverage.report]
 show_missing = true
-fail_under = 79
+fail_under = 93

--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -1,4 +1,5 @@
 coverage[toml] == 7.*
+coverage-conditional-plugin == 0.9.0
 pytest == 7.4.*
 pytest-cov == 4.1.*
 pytest-timeout == 2.2.*

--- a/src/openjd/adaptor_runtime/_background/frontend_runner.py
+++ b/src/openjd/adaptor_runtime/_background/frontend_runner.py
@@ -61,9 +61,9 @@ class FrontendRunner:
         self._connection_file_path = connection_file_path
         self._canceled = Event()
         signal.signal(signal.SIGINT, self._sigint_handler)
-        if OSName.is_posix():
+        if OSName.is_posix():  # pragma: is-windows
             signal.signal(signal.SIGTERM, self._sigint_handler)
-        else:
+        else:  # pragma: is-posix
             signal.signal(signal.SIGBREAK, self._sigint_handler)  # type: ignore[attr-defined]
 
     def init(
@@ -231,7 +231,7 @@ class FrontendRunner:
         params: dict | None = None,
         json_body: dict | None = None,
     ) -> http_client.HTTPResponse | Dict:
-        if OSName.is_windows():
+        if OSName.is_windows():  # pragma: is-posix
             return NamedPipeHelper.send_named_pipe_request(
                 self.connection_settings.socket,
                 self._timeout_s,
@@ -240,7 +240,7 @@ class FrontendRunner:
                 json_body=json_body,
                 params=params if params else None,
             )
-        else:
+        else:  # pragma: is-windows
             return self._send_linux_request(
                 method,
                 path,
@@ -255,7 +255,7 @@ class FrontendRunner:
         *,
         params: dict | None = None,
         json_body: dict | None = None,
-    ) -> http_client.HTTPResponse:
+    ) -> http_client.HTTPResponse:  # pragma: is-windows
         conn = UnixHTTPConnection(self.connection_settings.socket, timeout=self._timeout_s)
 
         if params:

--- a/test/openjd/adaptor_runtime/integ/background/test_background_mode.py
+++ b/test/openjd/adaptor_runtime/integ/background/test_background_mode.py
@@ -127,7 +127,7 @@ class TestDaemonMode:
         assert all(
             [
                 # TODO: Investigate why we need more time in Windows
-                _wait_for_file_deletion(p, timeout_s=(1 if OSName.is_posix() else 5))
+                _wait_for_file_deletion(p, timeout_s=(1 if OSName.is_posix() else 10))
                 for p in [connection_file_path, conn_settings.socket]
             ]
         )


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Windows-only code should not be checked for coverage on posix, and vice versa.

### What was the solution? (How)
Use [coverage-conditional-plugin](https://pypi.org/project/coverage-conditional-plugin/) to conditionally omit code blocks based on OS.

### What is the impact of this change?
Coverage checks more accurately represent the code covered on a given OS.

### How was this change tested?
Tests pass

### Was this change documented?
No

### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*