### PR TITLE
fix: Fix time out issues during NamedPipe Server shutdown.

### DIFF
--- a/hatch.toml
+++ b/hatch.toml
@@ -6,7 +6,7 @@ pre-install-commands = [
 [envs.default.scripts]
 sync = "pip install -r requirements-testing.txt"
 test = "pytest --cov-config pyproject.toml {args:test}"
-test-windows = "pytest --cov-config pyproject.toml {args:test/openjd/adaptor_runtime/integ/background test/openjd/adaptor_runtime/integ/_named_pipe test/openjd/adaptor_runtime/integ/process test/openjd/adaptor_runtime/unit/adaptors/configuration/test_configuration_manager.py} --cov-fail-under=50"
+test-windows = "pytest --cov-config pyproject.toml {args:test/openjd/adaptor_runtime/integ/background test/openjd/adaptor_runtime/integ/_named_pipe test/openjd/adaptor_runtime/integ/process test/openjd/adaptor_runtime/integ/application_ipc test/openjd/adaptor_runtime/unit/adaptors/configuration/test_configuration_manager.py} --cov-fail-under=50"
 typing = "mypy {args:src test}"
 style = [
   "ruff {args:.}",

--- a/test/openjd/adaptor_runtime/integ/background/test_background_mode.py
+++ b/test/openjd/adaptor_runtime/integ/background/test_background_mode.py
@@ -127,7 +127,7 @@ class TestDaemonMode:
         assert all(
             [
                 # TODO: Investigate why we need more time in Windows
-                _wait_for_file_deletion(p, timeout_s=(1 if OSName.is_posix() else 10))
+                _wait_for_file_deletion(p, timeout_s=(1 if OSName.is_posix() else 5))
                 for p in [connection_file_path, conn_settings.socket]
             ]
         )


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The I/O may be blocked during NamedPipe Server shutdown, which causes  a time out issue.

### What was the solution? (How)
After setting the shutdown signal and before closing all handles, try to connect to the server again to unblock the I/O.

### What is the impact of this change?
The shutdown behavior should be back to normal.

### How was this change tested?
Enable the `test/openjd/adaptor_runtime/integ/application_ipc` test in the Github CI. I forgot to enable this test in previous PR.

### Was this change documented?
NO

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*