### PR TITLE
feat: Validate the request path and method before handling it.

### DIFF
--- a/src/openjd/adaptor_runtime/_background/frontend_runner.py
+++ b/src/openjd/adaptor_runtime/_background/frontend_runner.py
@@ -232,13 +232,17 @@ class FrontendRunner:
         json_body: dict | None = None,
     ) -> http_client.HTTPResponse | Dict:
         if OSName.is_windows():  # pragma: is-posix
+            if params:
+                # This is used for aligning to the Linux's behavior in order to reuse the code in handler.
+                # In linux, query string params will always be put in a list.
+                params = {key: [value] for key, value in params.items()}
             return NamedPipeHelper.send_named_pipe_request(
                 self.connection_settings.socket,
                 self._timeout_s,
                 method,
                 path,
                 json_body=json_body,
-                params=params if params else None,
+                params=params,
             )
         else:  # pragma: is-windows
             return self._send_linux_request(

--- a/src/openjd/adaptor_runtime/_background/http_server.py
+++ b/src/openjd/adaptor_runtime/_background/http_server.py
@@ -118,24 +118,9 @@ class HeartbeatHandler(BackgroundResourceRequestHandler):
     """
 
     path: str = "/heartbeat"
-    _ACK_ID_KEY = ServerResponseGenerator.ACK_ID_KEY
 
     def get(self) -> HTTPResponse:
-        return self.server_response.generate_heartbeat_get_response(self._parse_ack_id)
-
-    def _parse_ack_id(self) -> str | None:
-        """
-        Parses chunk ID ACK from the query string. Returns None if the chunk ID ACK was not found.
-        """
-        if self._ACK_ID_KEY in self.query_string_params:
-            ack_ids: list[str] = self.query_string_params[self._ACK_ID_KEY]
-            if len(ack_ids) > 1:
-                raise ValueError(
-                    f"Expected one value for {self._ACK_ID_KEY}, but found: {len(ack_ids)}"
-                )
-            return ack_ids[0]
-
-        return None
+        return self.server_response.generate_heartbeat_get_response()
 
 
 class ShutdownHandler(BackgroundResourceRequestHandler):

--- a/test/openjd/adaptor_runtime/integ/application_ipc/test_integration_adaptor_ipc.py
+++ b/test/openjd/adaptor_runtime/integ/application_ipc/test_integration_adaptor_ipc.py
@@ -2,6 +2,7 @@
 
 import threading as _threading
 from time import sleep as _sleep
+from typing import Dict
 from unittest import mock as _mock
 
 import pytest
@@ -12,6 +13,9 @@ from openjd.adaptor_runtime.application_ipc import ActionsQueue as _ActionsQueue
 from .fake_app_client import FakeAppClient as _FakeAppClient
 from openjd.adaptor_runtime._osname import OSName
 from openjd.adaptor_runtime.application_ipc import AdaptorServer as _AdaptorServer
+
+if OSName.is_windows():
+    from openjd.adaptor_runtime._named_pipe.named_pipe_helper import NamedPipeHelper
 
 
 @pytest.fixture
@@ -196,3 +200,49 @@ class TestAdaptorIPC:
 
         # Verifying the test was successful.
         mocked_close.assert_called_once()
+
+    @pytest.mark.skipif(not OSName.is_windows(), reason="Windows named pipe test")
+    def test_adaptor_ipc_with_incorrect_request_path(self, adaptor: Adaptor):
+        # GIVEN
+        # Create a server and pass the actions queue.
+        test_server = _AdaptorServer(_ActionsQueue(), adaptor)
+
+        # Create thread for the AdaptorServer.
+        server_thread = _threading.Thread(target=start_test_server, args=(test_server,))
+        server_thread.start()
+
+        # WHEN
+        result: Dict = NamedPipeHelper.send_named_pipe_request(test_server.server_path, 5, "GET", "none")  # type: ignore
+        # Cleanup
+        test_server.shutdown()
+        server_thread.join()
+
+        # THEN
+        assert (
+            "Incorrect request path none. Only support following request path: /path_mapping /path_mapping_rules /action"
+            == result["body"]
+        )
+        assert 400 == result["status"]
+
+    @pytest.mark.skipif(not OSName.is_windows(), reason="Windows named pipe test")
+    def test_adaptor_ipc_with_incorrect_request_method(self, adaptor: Adaptor):
+        # GIVEN
+        # Create a server and pass the actions queue.
+        test_server = _AdaptorServer(_ActionsQueue(), adaptor)
+
+        # Create thread for the AdaptorServer.
+        server_thread = _threading.Thread(target=start_test_server, args=(test_server,))
+        server_thread.start()
+
+        # WHEN
+        result: Dict = NamedPipeHelper.send_named_pipe_request(test_server.server_path, 5, "none", "/action")  # type: ignore
+        # Cleanup
+        test_server.shutdown()
+        server_thread.join()
+
+        # THEN
+        assert (
+            "Incorrect request path none for the /action. Only support following request method: GET"
+            == result["body"]
+        )
+        assert 400 == result["status"]


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We use the NamedPipe to do the IPC in Windows. In order to align to the Linux's behavior. We are also using the request path and request method two parameters to identify the method that we will call in the server. The client could send any request path or request method and cause unexpected behaviors. We need to validate the request path and method before processing the request. 

### What was the solution? (How)
In this PR:

### What is the impact of this change?
Duplicated NamedPipe code in the background mode is removed and the code is more robust, due to adding input validation.

### How was this change tested?
All tests are passed.

### Was this change documented?
No.

### Is this a breaking change?
No.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*