### PR TITLE
refactor: Refactor the handle_request in the Windows background mode.

### DIFF
--- a/src/openjd/adaptor_runtime/_background/background_named_pipe_request_handler.py
+++ b/src/openjd/adaptor_runtime/_background/background_named_pipe_request_handler.py
@@ -65,30 +65,9 @@ class WinBackgroundResourceRequestHandler(ResourceRequestHandler):
             query_string_params,
         )
         try:
-            # TODO: Code refactoring to get rid of the `if...elif..` by using getattr
-            if path == "/run" and method == "PUT":
-                server_operation.generate_run_put_response()
-
-            elif path == "/shutdown" and method == "PUT":
-                server_operation.generate_shutdown_put_response()
-
-            elif path == "/heartbeat" and method == "GET":
-                _ACK_ID_KEY = ServerResponseGenerator.ACK_ID_KEY
-
-                def _parse_ack_id():
-                    if _ACK_ID_KEY in query_string_params:
-                        return query_string_params[_ACK_ID_KEY]
-
-                server_operation.generate_heartbeat_get_response(_parse_ack_id)
-
-            elif path == "/start" and method == "PUT":
-                server_operation.generate_start_put_response()
-
-            elif path == "/stop" and method == "PUT":
-                server_operation.generate_stop_put_response()
-
-            elif path == "/cancel" and method == "PUT":
-                server_operation.generate_cancel_put_response()
+            # Ignore the leading `/` in the path
+            method_name = f"generate_{path[1:]}_{method.lower()}_response"
+            getattr(server_operation, method_name)()
         except Exception as e:
             _logger.error(
                 f"Error encountered in request handling. "

--- a/src/openjd/adaptor_runtime/_background/frontend_runner.py
+++ b/src/openjd/adaptor_runtime/_background/frontend_runner.py
@@ -232,13 +232,17 @@ class FrontendRunner:
         json_body: dict | None = None,
     ) -> http_client.HTTPResponse | Dict:
         if OSName.is_windows():  # pragma: is-posix
+            if params:
+                # This is used for aligning to the Linux's behavior in order to reuse the code in handler.
+                # In linux, query string params will always be put in a list.
+                params = {key: [value] for key, value in params.items()}
             return NamedPipeHelper.send_named_pipe_request(
                 self.connection_settings.socket,
                 self._timeout_s,
                 method,
                 path,
                 json_body=json_body,
-                params=params if params else None,
+                params=params,
             )
         else:  # pragma: is-windows
             return self._send_linux_request(

--- a/src/openjd/adaptor_runtime/_background/http_server.py
+++ b/src/openjd/adaptor_runtime/_background/http_server.py
@@ -118,24 +118,9 @@ class HeartbeatHandler(BackgroundResourceRequestHandler):
     """
 
     path: str = "/heartbeat"
-    _ACK_ID_KEY = ServerResponseGenerator.ACK_ID_KEY
 
     def get(self) -> HTTPResponse:
-        return self.server_response.generate_heartbeat_get_response(self._parse_ack_id)
-
-    def _parse_ack_id(self) -> str | None:
-        """
-        Parses chunk ID ACK from the query string. Returns None if the chunk ID ACK was not found.
-        """
-        if self._ACK_ID_KEY in self.query_string_params:
-            ack_ids: list[str] = self.query_string_params[self._ACK_ID_KEY]
-            if len(ack_ids) > 1:
-                raise ValueError(
-                    f"Expected one value for {self._ACK_ID_KEY}, but found: {len(ack_ids)}"
-                )
-            return ack_ids[0]
-
-        return None
+        return self.server_response.generate_heartbeat_get_response()
 
 
 class ShutdownHandler(BackgroundResourceRequestHandler):

--- a/src/openjd/adaptor_runtime/application_ipc/_named_pipe_request_handler.py
+++ b/src/openjd/adaptor_runtime/application_ipc/_named_pipe_request_handler.py
@@ -45,8 +45,7 @@ class WinAdaptorServerResourceRequestHandler(ResourceRequestHandler):
             data: A string containing the message sent from the client.
         """
         request_dict = json.loads(data)
-        # Ignore the leading `/`
-        path = request_dict["path"][1:]
+        path = request_dict["path"]
         method: str = request_dict["method"]
 
         if "params" in request_dict and request_dict["params"] != "null":
@@ -58,7 +57,8 @@ class WinAdaptorServerResourceRequestHandler(ResourceRequestHandler):
             cast("WinAdaptorServer", self.server), self.send_response, query_string_params
         )
         try:
-            method_name = f"generate_{path}_{method.lower()}_response"
+            # Ignore the leading `/` in path
+            method_name = f"generate_{path[1:]}_{method.lower()}_response"
             getattr(server_operation, method_name)()
         except Exception as e:
             error_message = (


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
In the NamedPipe, we need to route the request manually, however, the function name is following the pattern `generate_{path[1:]}_{method.lower()}_response`, so we can use `getattr` to get the function instead of using `if...elif..`

This method is already used in the Adaptor IPC: https://github.com/xxyggoqtpcmcofkc/openjd-adaptor-runtime-for-python/pull/48/files#diff-cb8fc81db0e329e9706d9695dd821a4ce23e51f726eb1241e1beea78fa1868aeR62

We need to implement it in background mode to keep the consistent. 

### What was the solution? (How)
Use the `getattr` to call the function dynamically.

### What is the impact of this change?
Just a code refactoring. No logic is changed.

### How was this change tested?
All tests are passed.

### Was this change documented?
No

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*