### PR TITLE
feat: Generate unique pipe name in Windows.

### DIFF
--- a/src/openjd/adaptor_runtime/_background/backend_runner.py
+++ b/src/openjd/adaptor_runtime/_background/backend_runner.py
@@ -19,6 +19,7 @@ from .._utils import secure_open
 if OSName.is_posix():
     from .http_server import BackgroundHTTPServer
 if OSName.is_windows():
+    from .._named_pipe.named_pipe_helper import NamedPipeHelper
     from .backend_named_pipe_server import WinBackgroundNamedPipeServer
 from .log_buffers import LogBuffer
 from .model import ConnectionSettings
@@ -74,9 +75,7 @@ class BackendRunner:
                 "runtime", create_dir=True
             )
         else:
-            # TODO: Do a code refactoring to generate the namedpipe server path by using the SocketDirectories
-            #  Need to check if the pipe name is used and the max length.
-            server_path = rf"\\.\pipe\AdaptorNamedPipe_{str(os.getpid())}"
+            server_path = NamedPipeHelper.generate_pipe_name("AdaptorNamedPipe")
 
         try:
             if OSName.is_windows():

--- a/src/openjd/adaptor_runtime/application_ipc/_win_adaptor_server.py
+++ b/src/openjd/adaptor_runtime/application_ipc/_win_adaptor_server.py
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 
-import os
 from threading import Event
 from pywintypes import HANDLE
 
 from ._named_pipe_request_handler import WinAdaptorServerResourceRequestHandler
 from .._named_pipe import ResourceRequestHandler
+from .._named_pipe.named_pipe_helper import NamedPipeHelper
 from .._named_pipe.named_pipe_server import NamedPipeServer
 
 
@@ -34,9 +34,8 @@ class WinAdaptorServer(NamedPipeServer):
             actions_queue: A queue used for storing all actions sent by the client.
             adaptor: The adaptor class used for reacting to the request.
         """
-        # TODO: Do a code refactoring to generate the namedpipe server path
-        #  Need to check if the pipe name is used and the max length.
-        self.server_path = rf"\\.\pipe\AdaptorServerNamedPipe_{str(os.getpid())}"
+        self.server_path = NamedPipeHelper.generate_pipe_name("AdaptorServerNamedPipe")
+
         shutdown_event = Event()
         super().__init__(self.server_path, shutdown_event)
 

--- a/test/openjd/adaptor_runtime/integ/_named_pipe/test_named_pipe_helper.py
+++ b/test/openjd/adaptor_runtime/integ/_named_pipe/test_named_pipe_helper.py
@@ -1,4 +1,5 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+import time
 
 from openjd.adaptor_runtime._osname import OSName
 import json
@@ -67,6 +68,29 @@ class TestNamedPipeHelper:
 
         # THEN
         assert response == json.loads(expected_response)
+
+    def test_check_named_pipe_exists(self):
+        """
+        Test if the script can check if a named pipe exists.
+        """
+
+        # GIVEN
+        pipe_name = r"\\.\pipe\test_if_named_pipe_exist"
+        assert not NamedPipeHelper.check_named_pipe_exists(pipe_name)
+        server_handle = NamedPipeHelper.create_named_pipe_server(pipe_name, TIMEOUT_SECONDS)
+
+        # WHEN
+        is_existed = False
+        # Need to wait for launching the NamedPipe Server
+        for _ in range(10):
+            if NamedPipeHelper.check_named_pipe_exists(pipe_name):
+                is_existed = True
+                break
+            time.sleep(1)
+
+        # THEN
+        win32file.CloseHandle(server_handle)
+        assert is_existed
 
     @pytest.mark.skipif(
         os.getenv("GITHUB_ACTIONS") != "true",


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Cannot create a name pipe if it already exists.

### What was the solution? (How)
Check if a name pipe exists before creating one. If it exists, the we will pick up a different name in a different pattern. 

### What is the impact of this change?
It will make the code more robust.

### How was this change tested?
All unit tests and integration test for the new functions.

### Was this change documented?
No

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*