### PR TITLE
test: Fix configuration manager integ tests on Windows

### DIFF
--- a/hatch.toml
+++ b/hatch.toml
@@ -7,16 +7,11 @@ pre-install-commands = [
 sync = "pip install -r requirements-testing.txt"
 test = "pytest --cov-config pyproject.toml {args:test}"
 test-windows = """pytest --cov-config pyproject.toml {args:} \
-  test/openjd/adaptor_runtime/integ/_named_pipe \
-  test/openjd/adaptor_runtime/integ/_utils \
-  test/openjd/adaptor_runtime/integ/application_ipc \
-  test/openjd/adaptor_runtime/integ/background \
-  test/openjd/adaptor_runtime/integ/process \
-  test/openjd/adaptor_runtime/unit/adaptors/configuration/test_configuration_manager.py \
+  test/openjd/adaptor_runtime/integ \
+  test/openjd/adaptor_runtime/unit/adaptors/configuration \
   test/openjd/adaptor_runtime/unit/process \
   test/openjd/adaptor_runtime/unit/utils \
-  --cov-fail-under=50"""
-
+  --cov-fail-under=77"""
 typing = "mypy {args:src test}"
 style = [
   "ruff {args:.}",

--- a/test/openjd/adaptor_runtime/conftest.py
+++ b/test/openjd/adaptor_runtime/conftest.py
@@ -19,26 +19,12 @@ def pytest_collection_modifyitems(items):
     if OSName.is_windows():
         # Add the tests' paths that we want to enable in Windows
         do_not_skip_paths = [
-            os.path.join(os.path.abspath(os.path.dirname(__file__)), "integ", "_named_pipe"),
-            os.path.join(os.path.abspath(os.path.dirname(__file__)), "integ", "background"),
-            os.path.join(os.path.abspath(os.path.dirname(__file__)), "integ", "process"),
-            os.path.join(os.path.abspath(os.path.dirname(__file__)), "integ", "application_ipc"),
-            os.path.join(
-                os.path.abspath(os.path.dirname(__file__)),
-                "integ",
-                "test_integration_entrypoint.py",
-            ),
-            os.path.join(
-                os.path.abspath(os.path.dirname(__file__)),
-                "integ",
-                "_utils",
-            ),
+            os.path.join(os.path.abspath(os.path.dirname(__file__)), "integ"),
             os.path.join(
                 os.path.abspath(os.path.dirname(__file__)),
                 "unit",
                 "adaptors",
                 "configuration",
-                "test_configuration_manager.py",
             ),
             os.path.join(
                 os.path.abspath(os.path.dirname(__file__)),

--- a/test/openjd/adaptor_runtime/integ/adaptors/configuration/test_configuration.py
+++ b/test/openjd/adaptor_runtime/integ/adaptors/configuration/test_configuration.py
@@ -26,43 +26,52 @@ class TestFromFile:
         }
         config = {"key": "value"}
 
-        # fmt: off
-        with tempfile.NamedTemporaryFile(mode="w+") as schema_file, \
-                tempfile.NamedTemporaryFile(mode="w+") as config_file:
-            json.dump(json_schema, schema_file.file)
-            json.dump(config, config_file.file)
-            schema_file.seek(0)
-            config_file.seek(0)
+        try:
+            # GIVEN
+            with tempfile.NamedTemporaryFile(
+                mode="w+", delete=False
+            ) as schema_file, tempfile.NamedTemporaryFile(mode="w+", delete=False) as config_file:
+                json.dump(json_schema, schema_file.file)
+                json.dump(config, config_file.file)
+                schema_file.seek(0)
+                config_file.seek(0)
 
-            # WHEN
-            result = Configuration.from_file(
-                config_path=config_file.name,
-                schema_path=schema_file.name,
-            )
-        # fmt: on
+                # WHEN
+                result = Configuration.from_file(
+                    config_path=config_file.name,
+                    schema_path=schema_file.name,
+                )
 
-        # THEN
-        assert result._config == config
+            # THEN
+            assert result._config == config
 
-        schema_file.close()
-        config_file.close()
+        finally:
+            if os.path.exists(config_file.name):
+                os.remove(config_file.name)
+            if os.path.exists(schema_file.name):
+                os.remove(schema_file.name)
 
     def test_raises_when_config_file_fails_to_open(
         self, tmp_path: _pathlib.Path, caplog: pytest.LogCaptureFixture
     ):
-        # GIVEN
-        with tempfile.NamedTemporaryFile(mode="w+") as schema_file:
-            json.dump({}, schema_file.file)
-            schema_file.seek(0)
-            non_existent_filepath = os.path.join(tmp_path.absolute(), "non_existent_file")
+        try:
+            # GIVEN
+            with tempfile.NamedTemporaryFile(mode="w+", delete=False) as schema_file:
+                json.dump({}, schema_file.file)
+                schema_file.seek(0)
+                non_existent_filepath = os.path.join(tmp_path.absolute(), "non_existent_file")
 
-            # WHEN
-            with pytest.raises(OSError) as raised_err:
-                Configuration.from_file(
-                    schema_path=schema_file.name,
-                    config_path=non_existent_filepath,
-                )
+                # WHEN
+                with pytest.raises(OSError) as raised_err:
+                    Configuration.from_file(
+                        schema_path=schema_file.name,
+                        config_path=non_existent_filepath,
+                    )
 
-        # THEN
-        assert isinstance(raised_err.value, OSError)
-        assert f"Failed to open configuration at {non_existent_filepath}: " in caplog.text
+            # THEN
+            assert isinstance(raised_err.value, OSError)
+            assert f"Failed to open configuration at {non_existent_filepath}: " in caplog.text
+
+        finally:
+            if os.path.exists(schema_file.name):
+                os.remove(schema_file.name)

--- a/test/openjd/adaptor_runtime/integ/adaptors/configuration/test_configuration_manager.py
+++ b/test/openjd/adaptor_runtime/integ/adaptors/configuration/test_configuration_manager.py
@@ -12,10 +12,9 @@ import pytest
 from openjd.adaptor_runtime.adaptors.configuration import Configuration, ConfigurationManager
 
 
-@pytest.mark.Linux
-class TestConfigurationManagerLinux:
+class TestConfigurationManager:
     """
-    Linux-specific integration tests for ConfigurationManager
+    Integration tests for ConfigurationManager
     """
 
     @pytest.fixture
@@ -29,32 +28,38 @@ class TestConfigurationManagerLinux:
                 "usrkey": {"type": "string"},
             },
         }
-        with tempfile.NamedTemporaryFile(mode="w+") as schema_file:
+        with tempfile.NamedTemporaryFile(mode="w+", delete=False) as schema_file:
             json.dump(json_schema, schema_file.file)
             schema_file.seek(0)
             yield schema_file
+        os.remove(schema_file.name)
 
     def test_gets_system_config(self, json_schema_file: IO[str]):
         # GIVEN
         config = {"key": "value"}
 
-        with tempfile.NamedTemporaryFile(mode="w+") as config_file:
-            json.dump(config, config_file.file)
-            config_file.seek(0)
-            manager = ConfigurationManager(
-                config_cls=Configuration,
-                schema_path=json_schema_file.name,
-                system_config_path=config_file.name,
-                # These fields can be empty since they will not be used in this test
-                default_config_path="",
-                user_config_rel_path="",
-            )
+        try:
+            with tempfile.NamedTemporaryFile(mode="w+", delete=False) as config_file:
+                json.dump(config, config_file.file)
+                config_file.seek(0)
+                manager = ConfigurationManager(
+                    config_cls=Configuration,
+                    schema_path=json_schema_file.name,
+                    system_config_path=config_file.name,
+                    # These fields can be empty since they will not be used in this test
+                    default_config_path="",
+                    user_config_rel_path="",
+                )
 
-            # WHEN
-            sys_config = manager.get_system_config()
+                # WHEN
+                sys_config = manager.get_system_config()
 
-        # THEN
-        assert sys_config is not None and sys_config._config == config
+            # THEN
+            assert sys_config is not None and sys_config._config == config
+
+        finally:
+            if os.path.exists(config_file.name):
+                os.remove(config_file.name)
 
     def test_builds_config(self, json_schema_file: IO[str]):
         # GIVEN
@@ -66,32 +71,44 @@ class TestConfigurationManagerLinux:
         system_config = {"syskey": "system"}
         user_config = {"usrkey": "user"}
 
-        # fmt: off
         homedir = os.path.expanduser("~")
-        with tempfile.NamedTemporaryFile(mode="w+") as default_config_file, \
-                tempfile.NamedTemporaryFile(mode="w+") as system_config_file, \
-                tempfile.NamedTemporaryFile(mode="w+", dir=homedir) as user_config_file:
-            json.dump(default_config, default_config_file)
-            json.dump(system_config, system_config_file)
-            json.dump(user_config, user_config_file)
-            default_config_file.seek(0)
-            system_config_file.seek(0)
-            user_config_file.seek(0)
 
-            manager = ConfigurationManager(
-                config_cls=Configuration,
-                schema_path=json_schema_file.name,
-                default_config_path=default_config_file.name,
-                system_config_path=system_config_file.name,
-                user_config_rel_path=os.path.relpath(
-                    user_config_file.name,
-                    start=os.path.expanduser("~"),
-                ),
-            )
+        try:
+            with tempfile.NamedTemporaryFile(
+                mode="w+", delete=False
+            ) as default_config_file, tempfile.NamedTemporaryFile(
+                mode="w+", delete=False
+            ) as system_config_file, tempfile.NamedTemporaryFile(
+                mode="w+", dir=homedir, delete=False
+            ) as user_config_file:
+                json.dump(default_config, default_config_file)
+                json.dump(system_config, system_config_file)
+                json.dump(user_config, user_config_file)
+                default_config_file.seek(0)
+                system_config_file.seek(0)
+                user_config_file.seek(0)
 
-            # WHEN
-            result = manager.build_config()
-        # fmt: on
+                manager = ConfigurationManager(
+                    config_cls=Configuration,
+                    schema_path=json_schema_file.name,
+                    default_config_path=default_config_file.name,
+                    system_config_path=system_config_file.name,
+                    user_config_rel_path=os.path.relpath(
+                        user_config_file.name,
+                        start=os.path.expanduser("~"),
+                    ),
+                )
 
-        # THEN
-        assert result._config == {**default_config, **system_config, **user_config}
+                # WHEN
+                result = manager.build_config()
+
+                # THEN
+                assert result._config == {**default_config, **system_config, **user_config}
+
+        finally:
+            if os.path.exists(default_config_file.name):
+                os.remove(default_config_file.name)
+            if os.path.exists(system_config_file.name):
+                os.remove(system_config_file.name)
+            if os.path.exists(user_config_file.name):
+                os.remove(user_config_file.name)


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The `ConfigurationManager` and `Configuration` integration tests do not currently run on Windows. The same applies for the unit tests for the `Configuration` class. We want unit and integration tests to run for both classes on Windows.

### What was the solution? (How)
Add the `delete=False` parameter to the `NamedTemporaryFile` constructors in the test code. This mitigates a `PermissionDenied` error that occurs only on Windows and is discussed more in the [tempfile docs](https://docs.python.org/3/library/tempfile.html#tempfile.NamedTemporaryFile). Adding the `delete=False` parameter prevents the file from being automatically deleted on context manager exit. This means we need to explicitly remove the file using `os.remove(<path>)`.

### What is the impact of this change?
Unit and integration test coverage increases on Windows.

### How was this change tested?
Temporarily added assertions in the test code to ensure that the tempfiles are successfully removed by the `os.remove` call.

### Was this change documented?
No

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*