### PR TITLE
test: Enable all unit tests in Windows.

### DIFF
--- a/hatch.toml
+++ b/hatch.toml
@@ -7,11 +7,7 @@ pre-install-commands = [
 sync = "pip install -r requirements-testing.txt"
 test = "pytest --cov-config pyproject.toml {args:test}"
 test-windows = """pytest --cov-config pyproject.toml {args:} \
-  test/openjd/adaptor_runtime/integ \
-  test/openjd/adaptor_runtime/unit/adaptors/configuration \
-  test/openjd/adaptor_runtime/unit/process \
-  test/openjd/adaptor_runtime/unit/utils \
-  --cov-fail-under=77"""
+  test/openjd/adaptor_runtime --cov-fail-under=77"""
 typing = "mypy {args:src test}"
 style = [
   "ruff {args:.}",

--- a/test/openjd/adaptor_runtime/conftest.py
+++ b/test/openjd/adaptor_runtime/conftest.py
@@ -1,6 +1,6 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-import os
 import platform
+import os
 from typing import Generator
 
 from openjd.adaptor_runtime._osname import OSName
@@ -19,29 +19,7 @@ def pytest_collection_modifyitems(items):
     if OSName.is_windows():
         # Add the tests' paths that we want to enable in Windows
         do_not_skip_paths = [
-            os.path.join(os.path.abspath(os.path.dirname(__file__)), "integ"),
-            os.path.join(
-                os.path.abspath(os.path.dirname(__file__)),
-                "unit",
-                "adaptors",
-                "configuration",
-            ),
-            os.path.join(
-                os.path.abspath(os.path.dirname(__file__)),
-                "unit",
-                "named_pipe",
-                "test_named_pipe_helper.py",
-            ),
-            os.path.join(
-                os.path.abspath(os.path.dirname(__file__)),
-                "unit",
-                "process",
-            ),
-            os.path.join(
-                os.path.abspath(os.path.dirname(__file__)),
-                "unit",
-                "utils",
-            ),
+            os.path.abspath(os.path.dirname(__file__)),
         ]
         skip_marker = pytest.mark.skip(reason="Skipping tests on Windows")
         for item in items:

--- a/test/openjd/adaptor_runtime/unit/adaptors/test_base_adaptor.py
+++ b/test/openjd/adaptor_runtime/unit/adaptors/test_base_adaptor.py
@@ -9,6 +9,7 @@ import pytest
 from pytest import param
 
 import openjd.adaptor_runtime.adaptors._base_adaptor as base_adaptor
+from openjd.adaptor_runtime._osname import OSName
 from openjd.adaptor_runtime.adaptors._base_adaptor import (
     _ENV_CONFIG_PATH_TEMPLATE,
     _ENV_CONFIG_SCHEMA_PATH_PREFIX,
@@ -168,9 +169,14 @@ class TestConfigLoading:
         mock_package.return_value = package
         adaptor = FakeAdaptor({})
         adaptor_name = "FakeAdaptor"
-        additional_config_path = f"/path/to/additional/config/{adaptor_name}.json"
-        config_path = f"/path/to/config/{adaptor_name}.json"
-        schema_path = f"/path/to/schema/{adaptor_name}.schema.json"
+        if OSName.is_posix():
+            additional_config_path = f"/path/to/additional/config/{adaptor_name}.json"
+            config_path = f"/path/to/config/{adaptor_name}.json"
+            schema_path = f"/path/to/schema/{adaptor_name}.schema.json"
+        else:
+            additional_config_path = rf"C:\path\to\additional\config\{adaptor_name}.json"
+            config_path = rf"C:\path\to\config\{adaptor_name}.json"
+            schema_path = rf"C:\path\to\schema\{adaptor_name}.schema.json"
 
         mock_file.return_value = config_path
 

--- a/test/openjd/adaptor_runtime/unit/test_entrypoint.py
+++ b/test/openjd/adaptor_runtime/unit/test_entrypoint.py
@@ -286,7 +286,10 @@ class TestStart:
 
         # THEN
         signal_mock.assert_any_call(signal.SIGINT, entrypoint._sigint_handler)
-        signal_mock.assert_any_call(signal.SIGTERM, entrypoint._sigint_handler)
+        if OSName.is_posix():
+            signal_mock.assert_any_call(signal.SIGTERM, entrypoint._sigint_handler)
+        else:
+            signal_mock.assert_any_call(signal.SIGBREAK, entrypoint._sigint_handler)  # type: ignore[attr-defined]
         mock_adaptor_runner.return_value._cancel.assert_called_once()
 
     @patch.object(runtime_entrypoint, "InMemoryLogBuffer")


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Existing adaptor_runtime unit tests are not all enabled in the Windows OS.


### What was the solution? (How)
Enable All of them.


### What is the impact of this change?
All adaptor_runtime unit tests will be run in the Windows.

### How was this change tested?
This is a test change.


### Was this change documented?
No

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*