### PR TITLE
fix: Handle the error in the read_from_pipe_target correctly.

### DIFF
--- a/src/openjd/adaptor_runtime/_named_pipe/named_pipe_request_handler.py
+++ b/src/openjd/adaptor_runtime/_named_pipe/named_pipe_request_handler.py
@@ -65,7 +65,10 @@ class ResourceRequestHandler(ABC):
             self.handle_request(request_data)
         except PipeDisconnectedException as e:
             # Server is closed
-            _logger.info(f"NamedPipe Server is closed during reading message. {str(e)}")
+            _logger.debug(
+                f"NamedPipe Server is closed during reading message. {str(e)}"
+                f"{self._handler_type_name} instance thread exited."
+            )
             # Server is closed. No need to flush buffers or close handle.
             return
         except Exception:

--- a/src/openjd/adaptor_runtime/_named_pipe/named_pipe_server.py
+++ b/src/openjd/adaptor_runtime/_named_pipe/named_pipe_server.py
@@ -125,6 +125,7 @@ class NamedPipeServer(ABC):
                 else:
                     _logger.error(f"Error encountered while connecting to NamedPipe: {e} ")
             threading.Thread(target=self.request_handler(self, pipe_handle).instance_thread).start()
+        _logger.debug("Received Shutdown signal. Function serve_forever ended.")
 
     @abstractmethod
     def request_handler(


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

In the Windows Github Actions, we will see lots of exceptions, although all tests are passed, for example, [this one](https://github.com/OpenJobDescription/openjd-adaptor-runtime-for-python/actions/runs/7618034250/job/20748358294#step:11:38).

We need to fix it.

### What was the solution? (How)
In [previous commit](https://github.com/OpenJobDescription/openjd-adaptor-runtime-for-python/commit/7af1710a04df2bab8e43f4025c6781a883d21f53), we add a thread to support timeout. However, the error thrown in the new thread is not caught in the caller thread, which causes the failure in the error handling. 

 `ThreadPoolExecutor`  is a better choice here.

### What is the impact of this change?
We should not see any errors in the Github CI Windows Actions.

### How was this change tested?
Check [the log](https://github.com/OpenJobDescription/openjd-adaptor-runtime-for-python/actions/runs/7647834421/job/20839508550?pr=59#step:11:40) in the Github CI Actions.

### Was this change documented?
No

### Is this a breaking change?
NO

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*