### PR TITLE
fix(client): do not add signal handling if not running in the main thread

### DIFF
--- a/src/openjd/adaptor_runtime_client/posix_client_interface.py
+++ b/src/openjd/adaptor_runtime_client/posix_client_interface.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import signal as _signal
+import threading as _threading
 import warnings
 
 from .base_client_interface import Response as _Response
@@ -39,10 +40,11 @@ class HTTPClientInterface(BaseClientInterface):
 
         super().__init__(server_path)
 
-        # NOTE: The signals SIGKILL and SIGSTOP cannot be caught, blocked, or ignored.
-        # Reference: https://man7.org/linux/man-pages/man7/signal.7.html
-        # SIGTERM graceful shutdown.
-        _signal.signal(_signal.SIGTERM, self.graceful_shutdown)
+        if _threading.current_thread() is _threading.main_thread():
+            # NOTE: The signals SIGKILL and SIGSTOP cannot be caught, blocked, or ignored.
+            # Reference: https://man7.org/linux/man-pages/man7/signal.7.html
+            # SIGTERM graceful shutdown.
+            _signal.signal(_signal.SIGTERM, self.graceful_shutdown)
 
     @property
     def socket_path(self):

--- a/src/openjd/adaptor_runtime_client/win_client_interface.py
+++ b/src/openjd/adaptor_runtime_client/win_client_interface.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from .base_client_interface import Response as _Response
 import http.client
 import signal as _signal
+import threading as _threading
 
 
 from .base_client_interface import BaseClientInterface
@@ -21,7 +22,8 @@ class WinClientInterface(BaseClientInterface):
             server_path (str): Used as pipe name in Named Pipe Server.
         """
         super().__init__(server_path)
-        _signal.signal(_signal.SIGBREAK, self.graceful_shutdown)  # type: ignore[attr-defined]
+        if _threading.current_thread() is _threading.main_thread():
+            _signal.signal(_signal.SIGBREAK, self.graceful_shutdown)  # type: ignore[attr-defined]
 
     def _send_request(
         self,

--- a/test/openjd/adaptor_runtime_client/integ/fake_client.py
+++ b/test/openjd/adaptor_runtime_client/integ/fake_client.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+from argparse import ArgumentParser as _ArgumentParser
 from signal import Signals
 from time import sleep as _sleep
 from types import FrameType as _FrameType
+from threading import Thread as _Thread
 from typing import Any as _Any
 from typing import Dict as _Dict
 from typing import Optional as _Optional
@@ -33,5 +35,18 @@ class FakeClient(_ClientInterface):
             count += 1
 
 
-test_client = FakeClient("1234")
-test_client.run()
+def run_client():
+    test_client = FakeClient("1234")
+    test_client.run()
+
+
+if __name__ == "__main__":
+    parser = _ArgumentParser()
+    parser.add_argument("--run-in-thread", action="store_true")
+    args = parser.parse_args()
+
+    if args.run_in_thread:
+        threaded_client = _Thread(target=run_client)
+        threaded_client.start()
+    else:
+        run_client()

--- a/test/openjd/adaptor_runtime_client/integ/test_integration_client_interface.py
+++ b/test/openjd/adaptor_runtime_client/integ/test_integration_client_interface.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
-import os as _os
 import signal
 import sys
 import subprocess as _subprocess
+from os.path import dirname as _dirname, join as _join, realpath as _realpath
 from time import sleep as _sleep
 from typing import Dict, Any
 
@@ -13,14 +13,56 @@ from openjd.adaptor_runtime._osname import OSName
 
 
 class TestIntegrationClientInterface:
-    """ "These are the integration tests for the client interface."""
+    """These are the integration tests for the client interface."""
 
     def test_graceful_shutdown(self) -> None:
         # Create the subprocess
         popen_params: Dict[str, Any] = dict(
             args=[
                 sys.executable,
-                _os.path.join(_os.path.dirname(_os.path.realpath(__file__)), "fake_client.py"),
+                _join(_dirname(_realpath(__file__)), "fake_client.py"),
+            ],
+            stdin=_subprocess.PIPE,
+            stderr=_subprocess.PIPE,
+            stdout=_subprocess.PIPE,
+            encoding="utf-8",
+        )
+        if OSName.is_windows():
+            # In Windows, this is required for signal. SIGBREAK will be sent to the entire process group.
+            # Without this one, current process will also get the SIGBREAK and may react incorrectly.
+            popen_params.update(creationflags=_subprocess.CREATE_NEW_PROCESS_GROUP)  # type: ignore[attr-defined]
+        client_subprocess = _subprocess.Popen(**popen_params)
+
+        # To avoid a race condition, giving some extra time for the logging subprocess to start.
+        _sleep(0.5 if OSName.is_posix() else 4)
+        if OSName.is_windows():
+            signal_type = signal.CTRL_BREAK_EVENT  # type: ignore[attr-defined]
+        else:
+            signal_type = signal.SIGTERM
+
+        assert client_subprocess.returncode is None
+        client_subprocess.send_signal(signal_type)
+
+        # To avoid a race condition, giving some extra time for the log to be updated after
+        # receiving the signal.
+        _sleep(0.5 if OSName.is_posix() else 4)
+
+        out, _ = client_subprocess.communicate()
+
+        assert f"Received {'SIGBREAK' if OSName.is_windows() else 'SIGTERM'} signal." in out
+        # Ensure the process actually shutdown
+        assert client_subprocess.returncode is not None
+
+    def test_client_in_thread_does_not_do_graceful_shutdown(self):
+        """Ensures that a client running in a thread does not crash by attempting to register a signal,
+        since they can only be created in the main thread. This means the graceful shutdown is effectively
+        ignored."""
+        # Create the subprocess
+        popen_params: Dict[str, Any] = dict(
+            args=[
+                sys.executable,
+                _join(_dirname(_realpath(__file__)), "fake_client.py"),
+                "--run-in-thread",
             ],
             stdin=_subprocess.PIPE,
             stderr=_subprocess.PIPE,
@@ -41,11 +83,13 @@ class TestIntegrationClientInterface:
             signal_type = signal.SIGTERM
 
         client_subprocess.send_signal(signal_type)
+        _sleep(0.5)
+        # Ensure the process is still running
+        assert client_subprocess.returncode is None
+        out, err = client_subprocess.communicate()
+        assert "ValueError: signal only works in main thread of the main interpreter" not in err
+        assert f"Received {'SIGBREAK' if OSName.is_windows() else 'SIGTERM'} signal." not in out
 
-        # To avoid a race condition, giving some extra time for the log to be updated after
-        # receiving the signal.
-        _sleep(0.5 if OSName.is_posix() else 4)
-
-        out, _ = client_subprocess.communicate()
-
-        assert f"Received {'SIGBREAK' if OSName.is_windows() else 'SIGTERM'} signal." in out
+        # Ensure the process stops
+        client_subprocess.kill()
+        assert client_subprocess.returncode not in (None, 0)


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Applications may force users to run scripts in a thread (ie. KeyShot), and are thus unable to register the signal handlers for an adaptor to perform a graceful shutdown.

```
ADAPTOR_OUTPUT: STDOUT: [I] Setup: 0.0%
ADAPTOR_OUTPUT: STDOUT: [D] Failure
ADAPTOR_OUTPUT: STDOUT: [D] Exit? false 0
ADAPTOR_OUTPUT: STDOUT: [W] Python errors:
ADAPTOR_OUTPUT: STDOUT: Traceback (most recent call last):
ADAPTOR_OUTPUT: STDOUT:   File "<string>", line 92, in <module>
ADAPTOR_OUTPUT: STDOUT:   File "<string>", line 87, in main
ADAPTOR_OUTPUT: STDOUT:   File "<string>", line 62, in __init__
ADAPTOR_OUTPUT: STDOUT:   File "[REDACTED]/Lib/site-packages\openjd\adaptor_runtime_client\win_client_interface.py", line 24, in __init__
ADAPTOR_OUTPUT: STDOUT:     _signal.signal(_signal.SIGTERM, self.graceful_shutdown)  # type: ignore[attr-defined]
ADAPTOR_OUTPUT: STDOUT:     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ADAPTOR_OUTPUT: STDOUT:   File "[REDACTED]/AppData/Local/Programs/Python/Python311/Lib\signal.py", line 56, in signal
ADAPTOR_OUTPUT: STDOUT:     handler = _signal.signal(_enum_to_int(signalnum), _enum_to_int(handler))
ADAPTOR_OUTPUT: STDOUT:               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ADAPTOR_OUTPUT: STDOUT: ValueError: signal only works in main thread of the main interpreter
ADAPTOR_OUTPUT: STDOUT: [C] Exiting KeyShot due to uncaught Python exception or script failure!
ADAPTOR_OUTPUT: STDOUT: [D] Processing KeyShot close
ADAPTOR_OUTPUT: STDOUT: [W] KContext::customEvent - ignored callback event at destruction p
```

### What was the solution? (How)

I've gone with the least disruptive change to the cancellation workflow, which is to only register the signal handler in the application client code if it's running in the main thread. 

It is a bit unfortunate that adaptors are still forced to register a graceful_shutdown function due to the abstract base class. This signals (heh) to me that there _should_ be a larger change around adaptors being able to opt-in to signal handling, since we don't know how the application itself handles these signals.

### What is the impact of this change?

Adaptors can be written for more applications!

### How was this change tested?

Tested this change with KeyShot, since it was the first known application that forced the client code to be run in a thread, but also added a test case to ensure we work when run from a thread.

```
hatch run fmt
hatch run lint
hatch build
hatch run test
```

### Was this change documented?

N/A - I think the larger fix is when we'll actually document.

### Is this a breaking change?

Fixing!

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*