### PR TITLE
feat: Add the ability for the adaptor to specify its reentry executable

### DIFF
--- a/src/openjd/adaptor_runtime/_entrypoint.py
+++ b/src/openjd/adaptor_runtime/_entrypoint.py
@@ -6,6 +6,7 @@ import logging
 import os
 import signal
 import sys
+from pathlib import Path
 from argparse import ArgumentParser, Namespace
 from types import FrameType as FrameType
 from typing import TYPE_CHECKING, Any, Optional, Type, TypeVar
@@ -92,9 +93,12 @@ class EntryPoint:
         # 'background' command
         self._adaptor_runner: Optional[AdaptorRunner] = None
 
-    def start(self) -> None:
+    def start(self, reentry_exe: Optional[Path] = None) -> None:
         """
         Starts the run of the adaptor.
+
+        Args:
+            reentry_exe (Path): The path to the binary executable that for adaptor reentry.
         """
         formatter = ConditionalFormatter(
             "%(levelname)s: %(message)s", ignore_patterns=[_OPENJD_LOG_REGEX]
@@ -214,7 +218,7 @@ class EntryPoint:
                             f"Adaptor module is not loaded: {self.adaptor_class.__module__}"
                         )
 
-                    frontend.init(adaptor_module, init_data, path_mapping_data)
+                    frontend.init(adaptor_module, init_data, path_mapping_data, reentry_exe)
                     frontend.start()
                 elif subcommand == "run":
                     frontend.run(run_data)

--- a/src/openjd/adaptor_runtime_client/__init__.py
+++ b/src/openjd/adaptor_runtime_client/__init__.py
@@ -1,12 +1,13 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
+import os
+
 from .action import Action
 from .base_client_interface import (
     PathMappingRule,
 )
-from ..adaptor_runtime._osname import OSName
 
-if OSName.is_posix():
+if os.name == "posix":
     from .posix_client_interface import HTTPClientInterface as ClientInterface
 
     # This is just for backward compatible

--- a/src/openjd/adaptor_runtime_client/win_client_interface.py
+++ b/src/openjd/adaptor_runtime_client/win_client_interface.py
@@ -9,6 +9,10 @@ import threading as _threading
 
 
 from .base_client_interface import BaseClientInterface
+
+# TODO: We need to remove this relative import, since it won't work with how
+#       we inject this module into DCCs. Likely by copying the function
+#       NamedPipeHelper.send_named_pipe_request into this adaptor_runtime_client namespace.
 from ..adaptor_runtime._named_pipe.named_pipe_helper import NamedPipeHelper
 
 _DEFAULT_TIMEOUT_IN_SECONDS = 15

--- a/test/openjd/adaptor_runtime/unit/test_entrypoint.py
+++ b/test/openjd/adaptor_runtime/unit/test_entrypoint.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import argparse
 import json
 import signal
+from pathlib import Path
+from typing import Optional
 from unittest.mock import ANY, MagicMock, Mock, PropertyMock, mock_open, patch
 
 import jsonschema
@@ -389,6 +391,13 @@ class TestStart:
         _parse_args_mock.assert_called_once()
         mock_magic_init.assert_called_once_with(conn_file)
 
+    @pytest.mark.parametrize(
+        argnames=("reentry_exe"),
+        argvalues=[
+            (None,),
+            (Path("reeentry_exe_value"),),
+        ],
+    )
     @patch.object(EntryPoint, "_parse_args")
     @patch.object(FrontendRunner, "__init__", return_value=None)
     @patch.object(FrontendRunner, "init")
@@ -399,6 +408,7 @@ class TestStart:
         mock_magic_init: MagicMock,
         mock_magic_start: MagicMock,
         _parse_args_mock: MagicMock,
+        reentry_exe: Optional[Path],
     ):
         # GIVEN
         conn_file = "/path/to/conn_file"
@@ -414,11 +424,11 @@ class TestStart:
         with patch.dict(
             runtime_entrypoint.sys.modules, {FakeAdaptor.__module__: mock_adaptor_module}
         ):
-            entrypoint.start()
+            entrypoint.start(reentry_exe=reentry_exe)
 
         # THEN
         _parse_args_mock.assert_called_once()
-        mock_magic_init.assert_called_once_with(mock_adaptor_module, {}, {})
+        mock_magic_init.assert_called_once_with(mock_adaptor_module, {}, {}, reentry_exe)
         mock_magic_start.assert_called_once_with(conn_file)
         mock_start.assert_called_once_with()
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

For the updated packaging structure we've chosen, the entry point updates the `sys.path` without modifying `PYTHONPATH`. This breaks the way that the adaptor was re-launching itself, because the module was no longer included.

Additionally, there was a relative import to _OSName that broke the mechanism for injecting the `openjd` module into a DCC.

### What was the solution? (How)

- Add the ability for the adaptor to specify its reentry executable. This way the entry point can apply the `sys.path` update in that reentry.
- Also remove the relative import to _OSName and just use os.name so that it is compatible with how we inject the module into DCCs.

### What is the impact of this change?

Adaptors will work with our updated packaging structure.

### How was this change tested?

Created packages without this fix, observed that they did not work. Then created packages with this fix, after which they worked. Also created unit tests to check the reentry_exe parameter passing pattern.

### Was this change documented?

No

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*