### PR TITLE
chore(release): fix the release workflow

### DIFF
--- a/.github/scripts/get_latest_changelog.py
+++ b/.github/scripts/get_latest_changelog.py
@@ -4,17 +4,17 @@ This script gets the changelog notes for the latest version of this package. It 
 1. A file called CHANGELOG.md is in the current directory that has the changelog
 2. The changelog file is formatted in a way such that level 2 headers are:
     a. The only indication of the beginning of a version's changelog notes.
-    b. Always begin with `## v` (i.e. v1.2.3)
+    b. Always begin with `## `
 3. The changelog file contains the newest version's changelog notes at the top of the file.
 
 Example CHANGELOG.md:
 ```
-## v1.0.0 (2024-02-06)
+## 1.0.0 (2024-02-06)
 
 ### BREAKING CHANGES
 * **api**: rename all APIs
 
-## v0.1.0 (2024-02-06)
+## 0.1.0 (2024-02-06)
 
 ### Features
 * **api**: add new api
@@ -22,7 +22,7 @@ Example CHANGELOG.md:
 
 Running this script on the above CHANGELOG.md should return the following contents:
 ```
-## v1.0.0 (2024-02-06)
+## 1.0.0 (2024-02-06)
 
 ### BREAKING CHANGES
 * **api**: rename all APIs
@@ -31,7 +31,7 @@ Running this script on the above CHANGELOG.md should return the following conten
 """
 import re
 
-h2 = r"^##\sv.*$"
+h2 = r"^##\s.*$"
 with open("CHANGELOG.md") as f:
     contents = f.read()
 matches = re.findall(h2, contents, re.MULTILINE)

--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -2,7 +2,7 @@ name: Code Quality
 
 on:
   pull_request:
-    branches: [ mainline ]
+    branches: [ mainline, release ]
   workflow_call:
     inputs:
       branch:
@@ -14,5 +14,4 @@ jobs:
     name: Code Quality
     uses: ./.github/workflows/reuse_python_build.yml
     secrets: inherit
-    if: always()
 

--- a/.github/workflows/release_bump.yml
+++ b/.github/workflows/release_bump.yml
@@ -13,6 +13,9 @@ on:
         - minor
         - major
 
+concurrency:
+  group: release
+
 jobs:
   TestMainline:
     name: Test Mainline
@@ -24,6 +27,7 @@ jobs:
   Bump:
     needs: TestMainline
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: write
       pull-requests: write
@@ -42,7 +46,7 @@ jobs:
 
       - name: ConfigureGit
         run: |
-          git config --local user.email "client-software-ci@amazon.com"
+          git config --local user.email "129794699+client-software-ci@users.noreply.github.com"
           git config --local user.name "client-software-ci"
 
       - name: MergePushRelease
@@ -58,6 +62,7 @@ jobs:
           fi
 
           # Backup actual changelog to preserve its contents
+          touch CHANGELOG.md
           cp CHANGELOG.md CHANGELOG.bak.md
 
           # Run semantic-release to generate new changelog

--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -8,6 +8,9 @@ on:
     paths:
       - CHANGELOG.md
 
+concurrency:
+  group: release
+
 jobs:
   VerifyCommit:
     runs-on: ubuntu-latest
@@ -22,7 +25,7 @@ jobs:
 
       - name: VerifyAuthor
         run: |
-          EXPECTED_AUTHOR="client-software-ci@amazon.com"
+          EXPECTED_AUTHOR="129794699+client-software-ci@users.noreply.github.com"
           AUTHOR=$(git show -s --format='%ae' HEAD)
           if [[ $AUTHOR != $EXPECTED_AUTHOR ]]; then
             echo "ERROR: Expected author email to be '$EXPECTED_AUTHOR', but got '$AUTHOR'. Aborting release."
@@ -34,8 +37,15 @@ jobs:
   Release:
     needs: VerifyCommit
     runs-on: ubuntu-latest
+    environment: release
     permissions:
+      id-token: write
       contents: write
+    env:
+      CODEARTIFACT_REGION: "us-west-2"
+      CODEARTIFACT_DOMAIN: ${{ secrets.CODEARTIFACT_DOMAIN }}
+      CODEARTIFACT_ACCOUNT_ID: ${{ secrets.CODEARTIFACT_ACCOUNT_ID }}
+      CODEARTIFACT_REPOSITORY: ${{ secrets.CODEARTIFACT_REPOSITORY }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -65,9 +75,9 @@ jobs:
           NEXT_SEMVER=$(python -c 'import sys, re; print(re.match(r"chore\(release\): ([0-9]+\.[0-9]+\.[0-9]+).*", sys.argv[1]).group(1))' "$COMMIT_TITLE")
 
           # The format of the tag must match the pattern in pyproject.toml -> tool.semantic_release.tag_format
-          TAG="v$NEXT_SEMVER"
+          TAG="$NEXT_SEMVER"
 
-          git config --local user.email "client-software-ci@amazon.com"
+          git config --local user.email "129794699+client-software-ci@users.noreply.github.com"
           git config --local user.name "client-software-ci"
 
           git tag -a $TAG -m "Release $TAG"
@@ -80,11 +90,42 @@ jobs:
             echo EOF
           } >> $GITHUB_ENV
 
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_CODEARTIFACT_ROLE }}
+          aws-region: us-west-2
+          mask-aws-account-id: true
+
       # Tag must be made before building so the generated _version.py files have the correct version
       - name: Build
         run: |
+          export CODEARTIFACT_AUTH_TOKEN=$(aws codeartifact get-authorization-token --domain ${{ secrets.CODEARTIFACT_DOMAIN }} --domain-owner ${{ secrets.CODEARTIFACT_ACCOUNT_ID }} --query authorizationToken --output text --region us-west-2)
           pip install --upgrade hatch
           hatch build
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_PGP_KEY_SECRET_ROLE }}
+          aws-region: us-west-2
+          mask-aws-account-id: true
+
+      - name: Import PGP Key
+        run: |
+          export SECRET_STRING="$(aws secretsmanager get-secret-value --secret-id ${{ secrets.AWS_PGP_KEY_SECRET }} --query 'SecretString')"
+          printenv SECRET_STRING | jq -r '. | fromjson | .PrivateKey' | gpg --batch --pinentry-mode loopback --import --armor
+
+          PGP_KEY_PASSPHRASE=$(printenv SECRET_STRING | jq -r '. | fromjson | .Passphrase')
+          echo "::add-mask::$PGP_KEY_PASSPHRASE"
+          echo "PGP_KEY_PASSPHRASE=$PGP_KEY_PASSPHRASE" >> $GITHUB_ENV
+
+      - name: Sign
+        run: |
+          for file in dist/*; do
+            printenv PGP_KEY_PASSPHRASE | gpg --batch --pinentry-mode loopback --local-user "Open Job Description" --passphrase-fd 0 --output $file.sig --detach-sign $file
+            echo "Created signature file for $file"
+          done
 
       - name: PushRelease
         env:
@@ -96,6 +137,7 @@ jobs:
   MergeBack:
     needs: Release
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: write
     steps:
@@ -104,6 +146,7 @@ jobs:
         with:
           ref: mainline
           fetch-depth: 0
+          token: ${{ secrets.CI_TOKEN }}
 
       - name: MergeBackMainline
         run: |
@@ -128,7 +171,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ needs.Release.outputs.tag }}
+          ref: release
           fetch-depth: 0
 
       - name: Configure AWS credentials
@@ -145,6 +188,9 @@ jobs:
 
       - name: Install dependencies
         run: |
+          CODEARTIFACT_AUTH_TOKEN=$(aws codeartifact get-authorization-token --domain ${{ secrets.CODEARTIFACT_DOMAIN }} --domain-owner ${{ secrets.CODEARTIFACT_ACCOUNT_ID }} --query authorizationToken --output text --region us-west-2)
+          echo "::add-mask::$CODEARTIFACT_AUTH_TOKEN"
+          echo CODEARTIFACT_AUTH_TOKEN=$CODEARTIFACT_AUTH_TOKEN >> $GITHUB_ENV
           pip install --upgrade hatch
           pip install --upgrade twine
 
@@ -164,6 +210,11 @@ jobs:
           export TWINE_PASSWORD=`aws codeartifact get-authorization-token --domain ${{ secrets.CUSTOMER_DOMAIN }} --domain-owner ${{ secrets.CODEARTIFACT_ACCOUNT_ID }} --query authorizationToken --output text`
           export TWINE_REPOSITORY_URL=`aws codeartifact get-repository-endpoint --domain ${{ secrets.CUSTOMER_DOMAIN }} --domain-owner ${{ secrets.CODEARTIFACT_ACCOUNT_ID }} --repository ${{ secrets.CUSTOMER_REPOSITORY }} --format pypi --query repositoryEndpoint --output text`
           twine upload dist/*
+
+      # TODO: Uncomment this block to publish to PyPI once this package is public
+      # # See https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-pypi
+      # - name: Publish to PyPI
+      #   uses: pypa/gh-action-pypi-publish@release/v1
 
   PublishToInternal:
     needs: Release

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@ To send us a pull request, please:
 5. Send us a pull request, answering any default questions in the pull request interface.
 6. Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.
 
-GitHub provides additional document on [forking a repository](https://help.github.com/articles/fork-a-repo/) and
+GitHub provides additional documentation on [forking a repository](https://help.github.com/articles/fork-a-repo/) and
 [creating a pull request](https://help.github.com/articles/creating-a-pull-request/).
 
 ## Finding contributions to work on
@@ -56,8 +56,12 @@ opensource-codeofconduct@amazon.com with any additional questions or comments.
 
 ## Security issue notifications
 
-If you discover a potential security issue in this project we ask that you notify AWS/Amazon Security via our [vulnerability reporting page](http://aws.amazon.com/security/vulnerability-reporting/). Please do **not** create a public github issue.
-
+We take all security reports seriously. When we receive such reports, we will 
+investigate and subsequently address any potential vulnerabilities as quickly 
+as possible. If you discover a potential security issue in this project, please 
+notify AWS/Amazon Security via our [vulnerability reporting page](http://aws.amazon.com/security/vulnerability-reporting/)
+or directly via email to [AWS Security](aws-security@amazon.com). Please do not 
+create a public GitHub issue in this project.
 
 ## Licensing
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,33 @@
 This package provides a runtime library that can be used to implement a CLI adaptor interface around
 a desired application.
 
+## Compatibility
+
+This library requires:
+
+1. Python 3.9 or higher; and
+2. Linux, MacOS, or Windows operating system.
+
+## Versioning
+
+This package's version follows [Semantic Versioning 2.0](https://semver.org/), but is still considered to be in its 
+initial development, thus backwards incompatible versions are denoted by minor version bumps. To help illustrate how
+versions will increment during this initial development stage, they are described below:
+
+1. The MAJOR version is currently 0, indicating initial development. 
+2. The MINOR version is currently incremented when backwards incompatible changes are introduced to the public API. 
+3. The PATCH version is currently incremented when bug fixes or backwards compatible changes are introduced to the public API. 
+
+## Downloading
+
+You can download this package from:
+- [PyPI](https://pypi.org/project/openjd-adaptor-runtime/)
+- [GitHub releases](https://github.com/OpenJobDescription/openjd-adaptor-runtime-for-python/releases)
+
+### Verifying GitHub Releases
+
+See [VERIFYING_PGP_SIGNATURE](VERIFYING_PGP_SIGNATURE.md) for more information.
+
 ## Security
 
 See [CONTRIBUTING](CONTRIBUTING.md#security-issue-notifications) for more information.

--- a/VERIFYING_PGP_SIGNATURE.md
+++ b/VERIFYING_PGP_SIGNATURE.md
@@ -1,0 +1,101 @@
+## Verifying GitHub Releases
+
+You can verify the authenticity of the release artifacts using the `gpg` command line tool.
+
+1) Download the desired release artifacts from the GitHub releases page. Make sure to download the corresponding PGP signature file (ending with `.sig`) as well.
+For example, if you would like to verify your download of the wheel for version `1.2.3`, you should have the following files downloaded:
+    ```
+    openjd_adaptor_runtime-1.2.3-py3-none-any.whl
+    openjd_adaptor_runtime-1.2.3-py3-none-any.whl.sig
+    ```
+
+2) Install the `gpg` command line tool. The installation process varies by operating system. Please refer to the GnuPG website for instructions: https://gnupg.org/download/
+
+3) Save the following contents to a file called `openjobdescription-pgp.asc`:
+    ```
+    -----BEGIN PGP PUBLIC KEY BLOCK-----
+    
+    mQINBGXGjx0BEACdChrQ/nch2aYGJ4fxHNQwlPE42jeHECqTdlc1V/mug+7qN7Pc
+    C4NQk4t68Y72WX/NG49gRfpAxPlSeNt18c3vJ9/sWTukmonWYGK0jQGnDWjuVgFT
+    XtvJAAQBFilQXN8h779Th2lEuD4bQX+mGB7l60Xvh7vIehE3C4Srbp6KJXskPLPo
+    dz/dx7a+GXRiyYCYbGX4JziXSjQZRc0tIaxLn/GDm7VnXpdHcUk3qJitree61oC8
+    agtRHCH5s56E8wt8fXzyStElMkFIZsoLDlLp5lFqT81En9ho/+K6RLBkIj0mC8G7
+    BafpHKlxkrIgNK3pWACL93GE6xihqwkZMCAeqloVvkOTdfAKDHuDSEHwKxHG3cZ1
+    /e1YhtkPMVF+NMeoQavykUGVUT1bRoVNdk6bYsnbUjUI1A+JNf6MqvdRJyckZqEC
+    ylkBekBp/SFpFHvQkRCpfVizm2GSrjdZKgXpm1ZlQJyMRVzc/XPbqdSWhz52r3IC
+    eudwReHDc+6J5rs6tg3NbFfPVfCBMSqHlu1HRewWAllIp1+y6nfL4U3iEsUvZ1Y6
+    IV3defHIP3kNPU14ZWf3G5rvJDZrIRnjoWhDcaVmivmB/cSdDzphL5FovSI8dsPm
+    iU/JZGQb3EvZq+nl4pOiK32hETJ/fgCCzgUA3WqGeFNUNSI9KYZgBe6daQARAQAB
+    tDRPcGVuIEpvYiBEZXNjcmlwdGlvbiA8b3BlbmpvYmRlc2NyaXB0aW9uQGFtYXpv
+    bi5jb20+iQJXBBMBCABBFiEEvBcWYrv5OB7Tl2sZovDwWbzECYcFAmXGjx0DGy8E
+    BQkDwmcABQsJCAcCAiICBhUKCQgLAgMWAgECHgcCF4AACgkQovDwWbzECYcSHRAA
+    itPYx48xnJiT6tfnult9ZGivhcXhrMlvirVYOqEtRrt0l18sjr84K8mV71eqFwMx
+    GS7e4iQP6guqW9biQfMA5/Id8ZjE7jNbF0LUGsY6Ktj+yOlAbTR+x5qr7Svb7oEs
+    TMB/l9HBZ1WtIRzcUk9XYqzvYQr5TT997A63F28u32RchJ+5ECAz4g/p91aWxwVo
+    HIfN10sGzttoukJCzC10CZAVscJB+nnoUbB/o3bPak6GUxBHpMgomb0K5g4Z4fXY
+    4AZ9jKFoLgNcExdwteiUdSEnRorZ5Ny8sP84lwJziD3wuamVUsZ1C/KiQJBGTp5e
+    LUY38J1oIwptw5fqjaAq2GQxEaIknWQ4fr3ZvNYUuGUt5FbHe5U5XF34gC8PK7v7
+    bT/7sVdZZzKFScDLfH5N36M5FrXfTaXsVbfrRoa2j7U0kndyVEZyJsKVAQ8vgwbJ
+    w/w2hKkyQLAg3l5yO5CHLGatsfSIzea4WoOAaroxiNtL9gzVXzqpw6qPEsH9hsws
+    HsPEQWXHmDQvFTNUU14qic1Vc5fyxCBXIAGAPBd20b+219XznJ5uBKUgtvnqcItj
+    nMYe6Btxh+pjrTA15X/p81z6sB7dkL1hPHfawLhCEzJbIPyyBTQYqY00/ap4Rj7t
+    kzSiyzBejniFfAZ6eYBWsej7uXUsVndBF1ggZynPTeE=
+    =iaEm
+    -----END PGP PUBLIC KEY BLOCK-----
+    ```
+
+4) Import the OpenPGP key for Open Job Description by running the following command:
+
+    ```
+    gpg --import --armor openjobdescription-pgp.asc
+    ```
+
+5) Determine whether to trust the OpenPGP key. Some factors to consider when deciding whether or not to trust the above key are:
+
+    - The internet connection you’ve used to obtain the GPG key from this website is secure
+    - The device that you are accessing this website on is secure
+
+    If you have decided to trust the OpenPGP key, then edit the key to trust with `gpg` like the following example:
+    ```
+    $ gpg --edit-key A2F0F059BCC40987
+    gpg (GnuPG) 2.0.22; Copyright (C) 2013 Free Software Foundation, Inc.
+    This is free software: you are free to change and redistribute it.
+    There is NO WARRANTY, to the extent permitted by law.
+    
+    
+    pub  4096R/BCC40987  created: 2024-02-09  expires: 2026-02-08  usage: SCEA
+                         trust: unknown       validity: unknown
+    [ unknown] (1). Open Job Description <openjobdescription@amazon.com>
+    
+    gpg> trust
+    pub  4096R/BCC40987  created: 2024-02-09  expires: 2026-02-08  usage: SCEA
+                         trust: unknown       validity: unknown
+    [ unknown] (1). Open Job Description <openjobdescription@amazon.com>
+    
+    Please decide how far you trust this user to correctly verify other users' keys
+    (by looking at passports, checking fingerprints from different sources, etc.)
+    
+      1 = I don't know or won't say
+      2 = I do NOT trust
+      3 = I trust marginally
+      4 = I trust fully
+      5 = I trust ultimately
+      m = back to the main menu
+    
+    Your decision? 5
+    Do you really want to set this key to ultimate trust? (y/N) y
+    
+    pub  4096R/BCC40987  created: 2024-02-09  expires: 2026-02-08  usage: SCEA
+                         trust: ultimate      validity: unknown
+    [ unknown] (1). Open Job Description <openjobdescription@amazon.com>
+    Please note that the shown key validity is not necessarily correct
+    unless you restart the program.
+    
+    gpg> quit
+    ```
+
+6) Verify the signature of the Open Job Description release via `gpg --verify`. The command for verifying the example files from step 1 would be:
+
+    ```
+    gpg --verify ./openjd_adaptor_runtime-1.2.3-py3-none-any.whl.sig ./openjd_adaptor_runtime-1.2.3-py3-none-any.whl
+    ```

--- a/hatch.toml
+++ b/hatch.toml
@@ -33,8 +33,9 @@ build = "hatch build"
 PIP_INDEX_URL=""
 
 [envs.release]
-pre-install-commands = [
-  "pip install -r requirements-release.txt"
+detached = true
+dependencies = [
+  "python-semantic-release == 8.7.*"
 ]
 
 [envs.release.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -162,7 +162,7 @@ fail_under = 92
 [tool.semantic_release]
 # Can be removed or set to true once we are v1
 major_on_zero = false
-tag_format = "v{version}"
+tag_format = "{version}"
 
 [tool.semantic_release.publish]
 upload_to_vcs_release = false

--- a/requirements-release.txt
+++ b/requirements-release.txt
@@ -1,1 +1,3 @@
+# HACK: This file solely exists for dependabot checks. The actual dependencies are in `hatch.toml` in the `release` environment.
+# If dependabot opens a PR that modifies this file, please make sure to update the coresponding dependency in `hatch.toml` as well.
 python-semantic-release == 8.7.*


### PR DESCRIPTION
### PRE-MERGE CHECKLIST
- [x] Move the `CI_TOKEN` into the `release` environment.
- [x] Update the `release` environment to require an approval from "OpenJobDescription/developers" before running.
- [x] The `AWS_PGP_KEY_SECRET_ROLE` secret has been added to the `release` environment
- [x] The `AWS_PGP_KEY_SECRET` secret has been added to the `release` environment
- [x] Add `mainline` as a branch allowed to use `release` environment
- [x] Add `client-software-ci` to bypass required pull requests
- [x] Remove "Do not allow bypassing above rules" protection rule for `mainline`
- [x] Add "Restrict who can push to matching branches" protection rule for `mainline` and set it to the `client-software-ci` so `MergeBack` in `Release: Publish` can pass

### What was the problem/requirement? (What/Why)
The release workflow is currently broken

### What was the solution? (How)
Fix the release workflow

### What is the impact of this change?
Release workflow is fixed

### How was this change tested?
Tested on the other OpenJD repositories

### Was this change documented?
No

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*