### PR TITLE
feat!: add adaptor interface/data versioning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -157,7 +157,7 @@ is-posix = "sys_platform != 'win32'"
 
 [tool.coverage.report]
 show_missing = true
-fail_under = 92
+fail_under = 90
 
 [tool.semantic_release]
 # Can be removed or set to true once we are v1

--- a/src/openjd/adaptor_runtime/adaptors/__init__.py
+++ b/src/openjd/adaptor_runtime/adaptors/__init__.py
@@ -7,6 +7,7 @@ from ._base_adaptor import AdaptorConfigurationOptions, BaseAdaptor
 from ._command_adaptor import CommandAdaptor
 from ._path_mapping import PathMappingRule
 from ._validator import AdaptorDataValidator, AdaptorDataValidators
+from ._versioning import SemanticVersion
 
 __all__ = [
     "Adaptor",
@@ -18,4 +19,5 @@ __all__ = [
     "BaseAdaptor",
     "CommandAdaptor",
     "PathMappingRule",
+    "SemanticVersion",
 ]

--- a/src/openjd/adaptor_runtime/adaptors/_base_adaptor.py
+++ b/src/openjd/adaptor_runtime/adaptors/_base_adaptor.py
@@ -6,6 +6,7 @@ import logging
 import math
 import os
 import sys
+from abc import abstractproperty
 from dataclasses import dataclass
 from types import ModuleType
 from typing import Generic
@@ -18,6 +19,7 @@ from .configuration._configuration_manager import (
 )
 from ._adaptor_states import AdaptorStates
 from ._path_mapping import PathMappingRule
+from ._versioning import SemanticVersion
 
 __all__ = [
     "AdaptorConfigurationOptions",
@@ -87,6 +89,16 @@ class BaseAdaptor(AdaptorStates, Generic[_T]):
         Cancels the run of this adaptor.
         """
         self.on_cancel()
+
+    @abstractproperty
+    def integration_data_interface_version(self) -> SemanticVersion:
+        """
+        Returns a SemanticVersion of the data-interface.
+        Should be incremented when changes are made to any of the integration's:
+            - init-data schema
+            - run-data schema
+        """
+        pass
 
     @property
     def config_manager(self) -> ConfigurationManager[_T]:

--- a/src/openjd/adaptor_runtime/adaptors/_versioning.py
+++ b/src/openjd/adaptor_runtime/adaptors/_versioning.py
@@ -1,0 +1,62 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+import re
+
+from functools import total_ordering
+from typing import Any, NamedTuple
+
+VERSION_RE = re.compile(r"^\d*\.\d*$")
+
+
+@total_ordering
+class SemanticVersion(NamedTuple):
+    major: int
+    minor: int
+
+    def __str__(self):
+        return f"{self.major}.{self.minor}"
+
+    def __lt__(self, other: Any):
+        if not isinstance(other, SemanticVersion):
+            raise TypeError(f"Cannot compare SemanticVersion with {type(other)}")
+        if self.major < other.major:
+            return True
+        elif self.major == other.major:
+            if self.minor < other.minor:
+                return True
+        return False
+
+    def __eq__(self, other: Any) -> bool:
+        if not isinstance(other, SemanticVersion):
+            raise TypeError(f"Cannot compare SemanticVersion with {type(other).__name__}")
+        return self.major == other.major and self.minor == other.minor
+
+    def has_compatibility_with(self, other: "SemanticVersion") -> bool:
+        """
+        Returns a boolean representing if the version of self has compatibility with other.
+
+        This check is NOT commutative.
+        """
+        if not isinstance(other, SemanticVersion):
+            raise TypeError(
+                f"Cannot check compatibility of SemanticVersion with {type(other).__name__}"
+            )
+        if self.major == other.major == 0:
+            return self.minor == other.minor  # Pre-release versions treat minor as breaking
+        return self.major == other.major and self.minor >= other.minor
+
+    @classmethod
+    def parse(cls, version_str: str) -> "SemanticVersion":
+        """
+        Parses a version string into a SemanticVersion object.
+
+        Raises ValueError if the version string is not valid.
+        """
+        try:
+            if not VERSION_RE.match(version_str):
+                raise ValueError
+            major_str, minor_str = version_str.split(".")
+            major = int(major_str)
+            minor = int(minor_str)
+        except ValueError:
+            raise ValueError(f'Provided version "{version_str}" was not of form Major.Minor')
+        return SemanticVersion(major, minor)

--- a/test/openjd/adaptor_runtime/integ/IntegCommandAdaptor/adaptor.py
+++ b/test/openjd/adaptor_runtime/integ/IntegCommandAdaptor/adaptor.py
@@ -5,13 +5,17 @@ from typing import List
 from logging import getLogger
 
 from openjd.adaptor_runtime._osname import OSName
-from openjd.adaptor_runtime.adaptors import CommandAdaptor
+from openjd.adaptor_runtime.adaptors import CommandAdaptor, SemanticVersion
 from openjd.adaptor_runtime.process import ManagedProcess
 
 logger = getLogger(__name__)
 
 
 class IntegManagedProcess(ManagedProcess):
+    @property
+    def integration_data_interface_version(self) -> SemanticVersion:
+        return SemanticVersion(major=0, minor=1)
+
     def get_executable(self) -> str:
         if OSName.is_windows():
             # In Windows, we cannot directly execute the powershell script.
@@ -25,6 +29,10 @@ class IntegManagedProcess(ManagedProcess):
 
 
 class IntegCommandAdaptor(CommandAdaptor):
+    @property
+    def integration_data_interface_version(self) -> SemanticVersion:
+        return SemanticVersion(major=0, minor=1)
+
     def get_managed_process(self, run_data: dict) -> ManagedProcess:
         return IntegManagedProcess(run_data)
 

--- a/test/openjd/adaptor_runtime/integ/adaptors/test_integration_adaptor.py
+++ b/test/openjd/adaptor_runtime/integ/adaptors/test_integration_adaptor.py
@@ -6,7 +6,7 @@ import os
 import shutil
 from pathlib import Path
 
-from openjd.adaptor_runtime.adaptors import Adaptor
+from openjd.adaptor_runtime.adaptors import Adaptor, SemanticVersion
 
 
 class TestRun:
@@ -35,6 +35,10 @@ class TestRun:
                 for key, value in run_data.items():
                     print(f"\t{key} = {value}")
                 self.update_status(progress=second_progress, status_message=second_status_message)
+
+            @property
+            def integration_data_interface_version(self) -> SemanticVersion:
+                return SemanticVersion(major=0, minor=1)
 
         # GIVEN
         init_data: dict = {}
@@ -76,6 +80,10 @@ class TestRun:
                 parent_dir = path.parent.absolute()
                 os.remove(str(self.f))
                 shutil.rmtree(parent_dir)
+
+            @property
+            def integration_data_interface_version(self) -> SemanticVersion:
+                return SemanticVersion(major=0, minor=1)
 
         init_dict: dict = {}
         fa = FileAdaptor(init_dict)

--- a/test/openjd/adaptor_runtime/integ/adaptors/test_integration_path_mapping.py
+++ b/test/openjd/adaptor_runtime/integ/adaptors/test_integration_path_mapping.py
@@ -4,6 +4,7 @@ import pytest
 from unittest.mock import MagicMock
 from openjd.adaptor_runtime.adaptors import CommandAdaptor, PathMappingRule
 from openjd.adaptor_runtime.process import ManagedProcess
+from openjd.adaptor_runtime.adaptors import SemanticVersion
 
 
 class FakeCommandAdaptor(CommandAdaptor):
@@ -16,6 +17,10 @@ class FakeCommandAdaptor(CommandAdaptor):
 
     def get_managed_process(self, run_data: dict) -> ManagedProcess:
         return MagicMock()
+
+    @property
+    def integration_data_interface_version(self) -> SemanticVersion:
+        return SemanticVersion(major=0, minor=1)
 
 
 class TestGetPathMappingRules:

--- a/test/openjd/adaptor_runtime/integ/application_ipc/test_integration_adaptor_ipc.py
+++ b/test/openjd/adaptor_runtime/integ/application_ipc/test_integration_adaptor_ipc.py
@@ -8,7 +8,7 @@ from unittest import mock as _mock
 import pytest
 from openjd.adaptor_runtime_client import Action as _Action
 
-from openjd.adaptor_runtime.adaptors import Adaptor
+from openjd.adaptor_runtime.adaptors import Adaptor, SemanticVersion
 from openjd.adaptor_runtime.application_ipc import ActionsQueue as _ActionsQueue
 from .fake_app_client import FakeAppClient as _FakeAppClient
 from openjd.adaptor_runtime._osname import OSName
@@ -26,6 +26,10 @@ def adaptor():
 
         def on_run(self, run_data: dict):
             return
+
+        @property
+        def integration_data_interface_version(self) -> SemanticVersion:
+            return SemanticVersion(major=0, minor=1)
 
     path_mapping_rules = [
         {

--- a/test/openjd/adaptor_runtime/integ/background/sample_adaptor/adaptor.py
+++ b/test/openjd/adaptor_runtime/integ/background/sample_adaptor/adaptor.py
@@ -2,7 +2,7 @@
 
 import logging
 
-from openjd.adaptor_runtime.adaptors import Adaptor
+from openjd.adaptor_runtime.adaptors import Adaptor, SemanticVersion
 
 _logger = logging.getLogger(__name__)
 
@@ -14,6 +14,10 @@ class SampleAdaptor(Adaptor):
 
     def __init__(self, init_data: dict, **_):
         super().__init__(init_data)
+
+    @property
+    def integration_data_interface_version(self) -> SemanticVersion:
+        return SemanticVersion(major=0, minor=1)
 
     def on_start(self):
         _logger.info("on_start")

--- a/test/openjd/adaptor_runtime/unit/adaptors/fake_adaptor.py
+++ b/test/openjd/adaptor_runtime/unit/adaptors/fake_adaptor.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from openjd.adaptor_runtime.adaptors import BaseAdaptor
+from openjd.adaptor_runtime.adaptors import BaseAdaptor, SemanticVersion
 
 __all__ = ["FakeAdaptor"]
 
@@ -10,6 +10,10 @@ __all__ = ["FakeAdaptor"]
 class FakeAdaptor(BaseAdaptor):
     def __init__(self, init_data: dict, **kwargs):
         super().__init__(init_data, **kwargs)
+
+    @property
+    def integration_data_interface_version(self) -> SemanticVersion:
+        return SemanticVersion(major=0, minor=1)
 
     def _start(self):
         pass

--- a/test/openjd/adaptor_runtime/unit/adaptors/test_adaptor.py
+++ b/test/openjd/adaptor_runtime/unit/adaptors/test_adaptor.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from unittest.mock import Mock, patch
 
-from openjd.adaptor_runtime.adaptors import Adaptor
+from openjd.adaptor_runtime.adaptors import Adaptor, SemanticVersion
 
 
 class FakeAdaptor(Adaptor):
@@ -17,6 +17,10 @@ class FakeAdaptor(Adaptor):
 
     def on_run(self, run_data: dict):
         pass
+
+    @property
+    def integration_data_interface_version(self) -> SemanticVersion:
+        return SemanticVersion(major=0, minor=1)
 
 
 class TestRun:

--- a/test/openjd/adaptor_runtime/unit/adaptors/test_basic_adaptor.py
+++ b/test/openjd/adaptor_runtime/unit/adaptors/test_basic_adaptor.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
-from openjd.adaptor_runtime.adaptors import CommandAdaptor
+from openjd.adaptor_runtime.adaptors import CommandAdaptor, SemanticVersion
 from openjd.adaptor_runtime.process import ManagedProcess
 
 
@@ -18,6 +18,10 @@ class FakeCommandAdaptor(CommandAdaptor):
 
     def get_managed_process(self, run_data: dict) -> ManagedProcess:
         return MagicMock()
+
+    @property
+    def integration_data_interface_version(self) -> SemanticVersion:
+        return SemanticVersion(major=0, minor=1)
 
 
 class TestRun:

--- a/test/openjd/adaptor_runtime/unit/adaptors/test_versioning.py
+++ b/test/openjd/adaptor_runtime/unit/adaptors/test_versioning.py
@@ -1,0 +1,58 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+from __future__ import annotations
+
+import pytest
+from openjd.adaptor_runtime.adaptors import SemanticVersion
+
+
+class TestSemanticVersion:
+    @pytest.mark.parametrize(
+        ("version_a", "version_b", "expected_result"),
+        [
+            (SemanticVersion(0, 1), SemanticVersion(0, 2), False),
+            (SemanticVersion(0, 1), SemanticVersion(0, 1), True),
+            (SemanticVersion(0, 1), SemanticVersion(0, 0), False),
+            (SemanticVersion(1, 5), SemanticVersion(1, 4), True),
+            (SemanticVersion(1, 5), SemanticVersion(1, 5), True),
+            (SemanticVersion(1, 5), SemanticVersion(1, 6), False),
+            (SemanticVersion(1, 5), SemanticVersion(2, 0), False),
+            (SemanticVersion(1, 5), SemanticVersion(2, 5), False),
+            (SemanticVersion(1, 5), SemanticVersion(2, 6), False),
+        ],
+    )
+    def test_has_compatibility_with(
+        self, version_a: SemanticVersion, version_b: SemanticVersion, expected_result: bool
+    ):
+        # WHEN
+        result = version_a.has_compatibility_with(version_b)
+
+        # THEN
+        assert result == expected_result
+
+    @pytest.mark.parametrize(
+        ("version_str", "expected_result"),
+        [
+            ("1.0.0", ValueError),
+            ("1.zero", ValueError),
+            ("three.five", ValueError),
+            ("1. 5", ValueError),
+            (" 1.5", ValueError),
+            ("a version", ValueError),
+            ("-1.5", ValueError),
+            ("1.-5", ValueError),
+            ("-1.-5", ValueError),
+            ("1.5", SemanticVersion(1, 5)),
+            ("10.50", SemanticVersion(10, 50)),
+        ],
+    )
+    def test_parse(self, version_str: str, expected_result: SemanticVersion | ValueError):
+        if expected_result is ValueError:
+            # WHEN/THEN
+            with pytest.raises(ValueError):
+                SemanticVersion.parse(version_str)
+        else:
+            # WHEN
+            result = SemanticVersion.parse(version_str)
+
+            # THEN
+            assert result == expected_result


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The adaptor interfaces don't have any versioning, which means that creators of Job Templates will not be able to guarantee compatibility when submitting to a farm where both the runtime and adaptor versions can vary.

### What was the solution? (How)
- <BREAKING> Add abstract `integration_data_interface_version` property to the `BaseAdaptor`
 
- Add versioning to the adaptor CLI and `init-data`/`run-data` interfaces. 

- Add a `is-compatible` and `version-info` command.

`is-compatible` usage:
Help:
```bash
$ python -m IntegCommandAdaptor is-compatible -h
usage: IntegCommandAdaptor <command> [arguments] is-compatible [-h] --openjd-adaptor-cli-version <Major.Minor> --integration-data-interface-version <Major.Minor>

optional arguments:
  -h, --help            show this help message and exit
  --openjd-adaptor-cli-version <Major.Minor>
                        The version of the openjd adaptor CLI to compare with the installed adaptor.
  --integration-data-interface-version <Major.Minor>
                        The version of the IntegCommandAdaptor's data interface to compare with the installed adaptor.
```


Success:
```bash
$ python -m IntegCommandAdaptor is-compatible --openjd-adaptor-cli-version 0.1 --integration-data-interface-version 0.1
Installed interface versions are compatible with expected:
Installed:
        OpenJD Adaptor CLI Version: 0.1
        IntegCommandAdaptor Data Interface Version: 0.1
Expected:
        OpenJD Adaptor CLI Version: 0.1
        IntegCommandAdaptor Data Interface Version: 0.1
        
$ echo $?
0
```

Failure example
```bash
$ python -m IntegCommandAdaptor is-compatible --openjd-adaptor-cli-version 0.1 --integration-data-interface-version 0.2
Installed interface versions are incompatible with expected:
Installed:
        OpenJD Adaptor CLI Version: 0.1
        IntegCommandAdaptor Data Interface Version: 0.1
Expected:
        OpenJD Adaptor CLI Version: 0.1
        IntegCommandAdaptor Data Interface Version: 0.2
$ echo $?
2
```

`version-info` usage:

```bash
$ python -m IntegCommandAdaptor version-info
IntegCommandAdaptor Data Interface Version: '0.1'
OpenJD Adaptor CLI Version: '0.1'
```


### What is the impact of this change?

Consumers can build checks into their job templates which run pre-validation that the adaptor runtime and integration data interface is compatible with their job

### How was this change tested?

Manual testing as shown above

Unit tests added.


### Was this change documented?

Yes through the CLI help text.

### Is this a breaking change?
YES!

Consumers who subclass `BaseAdaptor` **MUST** implement the `integration_data_interface_version` property. 


----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*