### PR TITLE
feat!: show-config is now a command, slight refactor

### DIFF
--- a/src/openjd/adaptor_runtime/adaptors/_adaptor.py
+++ b/src/openjd/adaptor_runtime/adaptors/_adaptor.py
@@ -58,7 +58,7 @@ class Adaptor(BaseAdaptor[_T]):
 
     def _run(self, run_data: dict):
         """
-        :param run_data: This is the data that changes between the different SubTasks. Eg. frame
+        :param run_data: This is the data that changes between the different Tasks. Eg. frame
         number.
         """
         self.on_run(run_data)

--- a/test/openjd/adaptor_runtime/integ/IntegCommandAdaptor/adaptor.py
+++ b/test/openjd/adaptor_runtime/integ/IntegCommandAdaptor/adaptor.py
@@ -12,9 +12,6 @@ logger = getLogger(__name__)
 
 
 class IntegManagedProcess(ManagedProcess):
-    def __init__(self, run_data: dict) -> None:
-        super().__init__(run_data)
-
     def get_executable(self) -> str:
         if OSName.is_windows():
             # In Windows, we cannot directly execute the powershell script.
@@ -24,13 +21,10 @@ class IntegManagedProcess(ManagedProcess):
             return os.path.abspath(os.path.join(os.path.sep, "bin", "echo"))
 
     def get_arguments(self) -> List[str]:
-        return self.run_data.get("args", "")
+        return self.run_data.get("args", [""])
 
 
 class IntegCommandAdaptor(CommandAdaptor):
-    def __init__(self, init_data: dict, path_mapping_data: dict):
-        super().__init__(init_data, path_mapping_data=path_mapping_data)
-
     def get_managed_process(self, run_data: dict) -> ManagedProcess:
         return IntegManagedProcess(run_data)
 
@@ -38,10 +32,10 @@ class IntegCommandAdaptor(CommandAdaptor):
         # Print only goes to stdout and is not captured in daemon mode.
         print("prerun-print")
         # Logging is captured in daemon mode.
-        logger.info(self.init_data.get("on_prerun", ""))
+        logger.info(str(self.init_data.get("on_prerun", "")))
 
     def on_postrun(self):
         # Print only goes to stdout and is not captured in daemon mode.
         print("postrun-print")
         # Logging is captured in daemon mode.
-        logger.info(self.init_data.get("on_postrun", ""))
+        logger.info(str(self.init_data.get("on_postrun", "")))

--- a/test/openjd/adaptor_runtime/integ/adaptors/test_integration_adaptor.py
+++ b/test/openjd/adaptor_runtime/integ/adaptors/test_integration_adaptor.py
@@ -28,9 +28,6 @@ class TestRun:
             Test implementation of an Adaptor.
             """
 
-            def __init__(self, init_data: dict):
-                super().__init__(init_data)
-
             def on_run(self, run_data: dict):
                 # This run funciton will simply print the run_data.
                 self.update_status(progress=first_progress, status_message=first_status_message)
@@ -61,9 +58,6 @@ class TestRun:
         """
 
         class FileAdaptor(Adaptor):
-            def __init__(self, init_data: dict):
-                super().__init__(init_data)
-
             def on_start(self):
                 # Open a temp file
                 self.f = tmpdir.mkdir("test").join("hello.txt")

--- a/test/openjd/adaptor_runtime/integ/process/test_integration_managed_process.py
+++ b/test/openjd/adaptor_runtime/integ/process/test_integration_managed_process.py
@@ -24,9 +24,6 @@ class TestManagedProcess(object):
         """Testing a success case for the managed process."""
 
         class FakeManagedProcess(ManagedProcess):
-            def __init__(self, run_data: dict):
-                super(FakeManagedProcess, self).__init__(run_data)
-
             def get_executable(self) -> str:
                 if OSName.is_windows():
                     return "powershell.exe"

--- a/test/openjd/adaptor_runtime/unit/process/test_managed_process.py
+++ b/test/openjd/adaptor_runtime/unit/process/test_managed_process.py
@@ -50,9 +50,6 @@ class TestManagedProcess(object):
         startup_dir: str,
     ):
         class FakeManagedProcess(ManagedProcess):
-            def __init__(self, run_data: dict):
-                super(FakeManagedProcess, self).__init__(run_data)
-
             def get_executable(self) -> str:
                 return executable
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

When implementing https://github.com/OpenJobDescription/openjd-adaptor-runtime-for-python/pull/73 I discovered that the entrypoint was a bit hard to grasp, and that adding new commands didn't fit very well. Also various bugs and documentation missing.

### What was the solution? (How)

This PR accomplishes several things:
- Reduces the length of the `start()` method in the entry point from 130 LOC to 27
- Removes unnecessary `__init__` implementations in `Adaptor` subclasses in tests
- Fixes a bug in the `IntegCommandAdaptor` if the arguments passed in are not strings
- Fixes a bug in the `IntegManagerProcessed` where `get_arguments` return a string instread of a list
- Adds `help` text to some commands where it didn't exist prior
- Changes the `subcommands` parser to be titled `commands`
- \<BREAKING> Changes the `--show-config` argument to it's own `show-config` command since it doesn't play nice with other commands anyway
- Add handler for most commands to separate logic into digestible chunks
- Reduce reliance on mocking `_parse_args` in unit tests, instead mock  `sys.argv` so we can guarantee it works as expected, and the tests aren't brittle to adding a new command in the future. 
- \<BREAKING> If no command is specified, an error is thrown instead of defaulting to the `run` command. 

### What is the impact of this change?
The help text is a bit more clear

Examples with the `IntegCommandAdaptor`

Old:
```bash
$  python -m IntegCommandAdaptor --help
usage: adaptor_runtime [-h] [--show-config] {run,daemon} ...

optional arguments:
  -h, --help     show this help message and exit
  --show-config  When specified, the adaptor runtime configuration is printed then the program exits.

subcommands:
  {run,daemon}
```

New:
```bash
$  python -m IntegCommandAdaptor --help
usage: IntegCommandAdaptor <command> [arguments]

optional arguments:
  -h, --help            show this help message and exit

commands:
  {show-config,run,daemon}
    show-config         Prints the adaptor runtime configuration, then the program exits.
    run                 Run through the start, run, stop, cleanup adaptor states.
    daemon              Runs the adaptor in a daemon mode.
```


The interface of the CLI has changed for `--show-config`.

Old:
```
$  python -m IntegCommandAdaptor --show-config 
```

New:
```
$  python -m IntegCommandAdaptor show-config
```

Adaptors no long run the `run` command when provided no command. This was broken anyway because `init-data` and `run-data` couldn't be passed in due to how we construct the argparser.

Old:
```
$ python -m IntegCommandAdaptor
INFO: Applying user-level configuration: /home/samcan/.openjd/worker/adaptors/runtime/configuration.json
INFO: Applying user-level configuration: /home/samcan/.openjd/adaptors/IntegCommandAdaptor/IntegCommandAdaptor.json
prerun-print
INFO: 
openjd_fail: Error encountered while running adaptor: can only concatenate list (not "str") to list
ERROR: Error running the adaptor: can only concatenate list (not "str") to list
Entrypoint failed: can only concatenate list (not "str") to list
```

New:
```
$ python -m IntegCommandAdaptor 
INFO: Applying user-level configuration: /home/samcan/.openjd/worker/adaptors/runtime/configuration.json
usage: IntegCommandAdaptor <command> [arguments]

optional arguments:
  -h, --help            show this help message and exit

commands:
  {show-config,run,daemon}
    show-config         Prints the adaptor runtime configuration, then the program exits.
    run                 Run through the start, run, stop, cleanup adaptor states.
    daemon              Runs the adaptor in a daemon mode.
usage: IntegCommandAdaptor <command> [arguments]
adaptor_runtime: error: No command was provided.
```

### How was this change tested?

Manual testing depicted above, unit/integ tests pass.

### Was this change documented?

? 

### Is this a breaking change?

Yes
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*