### PR TITLE
fix: fix signal handling

### DIFF
--- a/src/openjd/adaptor_runtime_client/win_client_interface.py
+++ b/src/openjd/adaptor_runtime_client/win_client_interface.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from .base_client_interface import Response as _Response
 import http.client
 import signal as _signal
-import threading as _threading
 
 
 from .base_client_interface import BaseClientInterface
@@ -26,8 +25,10 @@ class WinClientInterface(BaseClientInterface):
             server_path (str): Used as pipe name in Named Pipe Server.
         """
         super().__init__(server_path)
-        if _threading.current_thread() is _threading.main_thread():
+        try:
             _signal.signal(_signal.SIGBREAK, self.graceful_shutdown)  # type: ignore[attr-defined]
+        except ValueError:
+            pass
 
     def _send_request(
         self,


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Some applications incorrectly determine they are running in the main thread on windows. 

### What was the solution? (How)
Catch a ValueError around the signal

### What is the impact of this change?


### How was this change tested?
Tested locally. Seems to fix the issue I was encountering. 

### Was this change documented?
no
### Is this a breaking change?
no
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*