### PR TITLE
chore: clean up some TODO comments

### DIFF
--- a/src/openjd/adaptor_runtime/_named_pipe/named_pipe_server.py
+++ b/src/openjd/adaptor_runtime/_named_pipe/named_pipe_server.py
@@ -5,7 +5,6 @@ import logging
 
 import threading
 from threading import Event
-import time
 
 from typing import List
 
@@ -135,14 +134,9 @@ class NamedPipeServer(ABC):
         """
         Shuts down the Named Pipe server and closes all named pipe handlers.
 
-        Signals the `serve_forever` method to stop listening to the NamedPipe Server by
-        pushing a `True` value into the `_cancel_queue`.
+        Signals the `serve_forever` method to stop listening to the NamedPipe Server.
         """
         self._shutdown_event.set()
-        # TODO: Need to find out a better way to wait for the communication finish
-        #  After sending the shutdown command, we need to wait for the response
-        #  from it before shutting down server or the client won't get the response.
-        time.sleep(1)
         error_list: List[Exception] = []
         try:
             # It is possible that the Server already start waiting for a connection from client.


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
There are some TODO comments needed to be cleaned before release. 

### What was the solution? (How)
1. Delete unnecessary sleep during server shutdown. We don't need it anymore, because we use the threading event for communication, and the server will wait for a final connection from the shutdown function to shutdown.  
1. Delete the additional `sleep` for Windows tests. The reason why we needed these `sleep` before is we misuse the overlapped mode in Named Pipe. This issue is fixed in previous PR.
2.    in the [test_background_mode.py](https://github.com/OpenJobDescription/openjd-adaptor-runtime-for-python/pull/85/files#diff-657c4bb3adc0f6f929c9777eda59a9333cb616ed291fbd85b5c6ad6bdc44fc94), completed the test code to validate the named pipe is established correctly. 

### What is the impact of this change?
Should not affect any functional code.

### How was this change tested?
I rerun the Github CI three times. Total 9(=3*3) Windows test suites are passed without any failures.

### Was this change documented?
N/A

### Is this a breaking change?
N/A


----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*