### PR TITLE
fix: specify max named pipe instances

### DIFF
--- a/src/openjd/adaptor_runtime/_background/server_config.py
+++ b/src/openjd/adaptor_runtime/_background/server_config.py
@@ -3,3 +3,6 @@
 # Windows Named Pipe Server Configuration
 NAMED_PIPE_BUFFER_SIZE = 8192
 DEFAULT_NAMED_PIPE_TIMEOUT_MILLISECONDS = 5000
+# This number must be >= 2, one instance is for normal operation communication
+# and the other one is for immediate shutdown communication
+DEFAULT_MAX_NAMED_PIPE_INSTANCES = 2

--- a/src/openjd/adaptor_runtime/_named_pipe/named_pipe_helper.py
+++ b/src/openjd/adaptor_runtime/_named_pipe/named_pipe_helper.py
@@ -19,7 +19,10 @@ from enum import Enum
 import os
 
 
-from openjd.adaptor_runtime._background.server_config import NAMED_PIPE_BUFFER_SIZE
+from openjd.adaptor_runtime._background.server_config import (
+    NAMED_PIPE_BUFFER_SIZE,
+    DEFAULT_MAX_NAMED_PIPE_INSTANCES,
+)
 
 _logger = logging.getLogger(__name__)
 
@@ -181,7 +184,7 @@ class NamedPipeHelper:
             # A bi-directional pipe; both server and client processes can read from and write to the pipe.
             win32pipe.PIPE_ACCESS_DUPLEX,
             win32pipe.PIPE_TYPE_MESSAGE | win32pipe.PIPE_READMODE_MESSAGE | win32pipe.PIPE_WAIT,
-            win32pipe.PIPE_UNLIMITED_INSTANCES,
+            DEFAULT_MAX_NAMED_PIPE_INSTANCES,
             NAMED_PIPE_BUFFER_SIZE,  # nOutBufferSize
             NAMED_PIPE_BUFFER_SIZE,  # nInBufferSize
             time_out_in_seconds,


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
In previous implementation, the max named pipe instances is not limited, which may run out of the resources. 

### What was the solution? (How)
Restrict the max number of the named pipe instances to avoid this risk.

### What is the impact of this change?
Make the code safer.

### How was this change tested?
All existing tests are passed.

### Was this change documented?
N/A

### Is this a breaking change?
N/A

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*