### PR TITLE
fix: increase max named pipe instances to 4

### DIFF
--- a/src/openjd/adaptor_runtime_client/named_pipe/named_pipe_config.py
+++ b/src/openjd/adaptor_runtime_client/named_pipe/named_pipe_config.py
@@ -5,4 +5,4 @@ NAMED_PIPE_BUFFER_SIZE = 8192
 DEFAULT_NAMED_PIPE_TIMEOUT_MILLISECONDS = 5000
 # This number must be >= 2, one instance is for normal operation communication
 # and the other one is for immediate shutdown communication
-DEFAULT_MAX_NAMED_PIPE_INSTANCES = 2
+DEFAULT_MAX_NAMED_PIPE_INSTANCES = 4


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We recently set a limit on how many named pipe instance can be created. When testing dcc applications it was found that instances were not enough, we needed to set at least 4.

### What was the solution? (How)
Increase DEFAULT_MAX_NAMED_PIPE_INSTANCES to 4.

### What is the impact of this change?
Now limits instance to 4

### How was this change tested?
Tested in a developer environment using the Keyshot and Unreal Engine with the Worker Agent.

### Was this change documented?
No

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*