### PR TITLE
fix: Add `delete` permission to the`secure_open`

### DIFF
--- a/src/openjd/adaptor_runtime/_utils/_secure_open.py
+++ b/src/openjd/adaptor_runtime/_utils/_secure_open.py
@@ -11,6 +11,7 @@ from .._osname import OSName
 if OSName.is_windows():
     import ntsecuritycon as con
     import win32security
+    import win32con
 
 from openjd.adaptor_runtime._osname import OSName
 
@@ -88,7 +89,7 @@ def get_file_owner_in_windows(filepath: "StrOrBytesPath") -> str:  # pragma: is-
 
 def set_file_permissions_in_windows(filepath: "StrOrBytesPath") -> None:  # pragma: is-posix
     """
-    Sets read and write permissions for the owner of the specified file.
+    Sets read, write and delete permissions for the owner of the specified file.
 
     Note: This function sets permissions only for the owner of the file and
     does not consider existing DACLs.
@@ -101,9 +102,10 @@ def set_file_permissions_in_windows(filepath: "StrOrBytesPath") -> None:  # prag
 
     dacl = win32security.ACL()
 
-    # Add read & write permissions
+    # Add read, write and delete permissions
     dacl.AddAccessAllowedAce(win32security.ACL_REVISION, con.FILE_GENERIC_READ, user_sid)
     dacl.AddAccessAllowedAce(win32security.ACL_REVISION, con.FILE_GENERIC_WRITE, user_sid)
+    dacl.AddAccessAllowedAce(win32security.ACL_REVISION, win32con.DELETE, user_sid)
 
     # Apply the DACL to the file
     sd = win32security.GetFileSecurity(filepath, win32security.DACL_SECURITY_INFORMATION)


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The Delete permission is missing in the `secure_open` in the Windows. It will cause that the connection file is not able to be deleted .

### What was the solution? (How)
Add the permission to the `secure_open` to allow the cleanup to clean up the files. 

### What is the impact of this change?
connection file should be deleted successfully.

### How was this change tested?
Due to an unexpected behavior within the system, I encountered limitations in directly testing this change. Specifically, files located under `C:\Users\user_name` can be deleted without requiring delete permissions. Therefore, [One of our test](https://github.com/OpenJobDescription/openjd-adaptor-runtime-for-python/blob/1398c562fead13564705329838a377468e11c2c1/test/openjd/adaptor_runtime/integ/background/test_background_mode.py#L141-L147) can delete the file without the delete permissions. Want to mention that permission inheritance has been explicitly disabled for these files, yet deletion is still possible. I need to investigate this issue outside of this PR.

I manually check the `delete` permission of the file create by the `secure_open` to confirm that the file owner have the permission to read, write and delete the file. So the permissions are updated. 

### Was this change documented?
N/A

### Is this a breaking change?
N/A

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*