### PR TITLE
chore: adds the homepage of the package to its metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,12 +27,16 @@ classifiers = [
   "License :: OSI Approved :: Apache Software License",
   "Intended Audience :: Developers",
 ]
-
 dependencies = [
   "pyyaml ~= 6.0",
   "jsonschema >= 4.17.0, == 4.*",
   "pywin32 == 306; platform_system == 'Windows'",
 ]
+
+[project.urls]
+Homepage = "https://github.com/OpenJobDescription/openjd-adaptor-runtime-for-python"
+Source = "https://github.com/OpenJobDescription/openjd-adaptor-runtime-for-python"
+
 
 [tool.hatch.build]
 artifacts = [


### PR DESCRIPTION

### What was the problem/requirement? (What/Why)

The landing page for this package on PyPI does not identify the homepage of the package. This is because the pyproject.toml is not setting the homepage or source metadata on the package.

### What was the solution? (How)

This sets the homepage & source metadata.

### What is the impact of this change?

People discovering the package on PyPI will be able to find the GitHub homepage for the package.

### How was this change tested?

It's a copy/paste from other repositories that we own and do the same.

### Was this change documented?

N/A

### Is this a breaking change?

No.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*