### PR TITLE
fix: set correct permission for the test directory.

### DIFF
--- a/test/openjd/adaptor_runtime/integ/background/test_background_mode.py
+++ b/test/openjd/adaptor_runtime/integ/background/test_background_mode.py
@@ -52,7 +52,18 @@ class TestDaemonMode:
 
     @pytest.fixture
     def connection_file_path(self, tmp_path: pathlib.Path) -> str:
-        return os.path.join(tmp_path.absolute(), "connection.json")
+        connection_dir = os.path.join(tmp_path.absolute(), "connection_dir")
+        os.mkdir(connection_dir)
+        if OSName.is_windows():
+            # In Windows, to prevent false positives in tests, it's crucial to remove the "Delete subfolders and files"
+            # permission from the parent folder. This step ensures that files cannot be deleted without explicit delete
+            # permissions, addressing an edge case where the same user owns both the parent folder and the file,
+            # bypassing delete permissions. `set_file_permissions_in_windows` will restrict the permission to read,
+            # write, delete current folder, which meets the requirement.
+            from openjd.adaptor_runtime._utils._secure_open import set_file_permissions_in_windows
+
+            set_file_permissions_in_windows(connection_dir)
+        return os.path.join(connection_dir, "connection.json")
 
     @pytest.fixture
     def initialized_setup(


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

`test_shutdown` test can pass without the delete permission of the file, which is affected by the parent folder's permission. 

Note: This will only happen when the owner of the file and its parent directory is the same. If UserA creates a folder named FolderA and has the 'Delete subfolders and files' permission on that folder, then UserA can delete any files or subfolders within FolderA, even if UserA doesn't have explicit delete permissions on those individual files or subfolders, as long as UserA is the owner of those files or subfolders.

However, if UserA creates a folder named FolderA and has the 'Delete subfolders and files' permission on that folder, UserA cannot delete any files or subfolders within FolderA if those files or subfolders are owned by another user, such as UserB, even if UserA has the 'Delete subfolders and files' permission on the parent folder FolderA.

### What was the solution? (How)

Remove the "Delete subfolders and files" of the parent folder of the connection file.


### What is the impact of this change?

It will fail the test if the `delete` permission is missing.

### How was this change tested?

I manually remove the `delete` permission of the connection file and the test will fail right now.

### Was this change documented?

N/A

### Is this a breaking change?
N/A

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*