### PR TITLE
ci: publish workfow needs content write permissions

### DIFF
--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -16,6 +16,6 @@ jobs:
     name: Publish Release
     permissions:
       id-token: write
-      contents: read
+      contents: write
     uses: OpenJobDescription/.github/.github/workflows/reusable_publish.yml@mainline
     secrets: inherit


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The Release job in the reusable publish workflow requires contents write permissons.

https://github.com/OpenJobDescription/.github/blob/mainline/.github/workflows/reusable_publish.yml#L35

### What was the solution? (How)
Add write permissions to the calling workflow.

### What is the impact of this change?
allows the calling workflow to pass contents write permissions to the reusable workflow

### How was this change tested?
Will be tested once deployed

### Was this change documented?
no

### Is this a breaking change?
no

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*