### PR TITLE
ci: add release env to pypi publish job

### DIFF
--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -24,6 +24,7 @@ jobs:
   PublishToPyPI:
     needs: Publish
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       id-token: write
     steps:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
release environment is missing in the PyPI publish job and is needed to publish to PyPI

### What was the solution? (How)
add the release environment

### What is the impact of this change?
Allows publishing to PyPI

### How was this change tested?
n/a

### Was this change documented?
no

### Is this a breaking change?
no

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*