### PR TITLE
fix!: handle socket name collisions

### DIFF
--- a/src/openjd/adaptor_runtime/_background/backend_runner.py
+++ b/src/openjd/adaptor_runtime/_background/backend_runner.py
@@ -8,7 +8,7 @@ import os
 import signal
 from threading import Thread, Event
 from types import FrameType
-from typing import Optional, Union
+from typing import Callable, List, Optional, Union
 
 from .server_response import ServerResponseGenerator
 from .._osname import OSName
@@ -87,7 +87,7 @@ class BackendRunner:
                 self._server, self._adaptor_runner._cancel, force_immediate=True
             )
 
-    def run(self) -> None:
+    def run(self, *, on_connection_file_written: List[Callable[[], None]] | None = None) -> None:
         """
         Runs the backend logic for background mode.
 
@@ -145,6 +145,11 @@ class BackendRunner:
             shutdown_event.set()
             raise
         finally:
+            if on_connection_file_written:
+                callbacks = list(on_connection_file_written)
+                for cb in callbacks:
+                    cb()
+
             # Block until the shutdown_event is set
             shutdown_event.wait()
 

--- a/src/openjd/adaptor_runtime/_background/backend_runner.py
+++ b/src/openjd/adaptor_runtime/_background/backend_runner.py
@@ -8,6 +8,7 @@ import os
 import signal
 from pathlib import Path
 from threading import Thread, Event
+import traceback
 from types import FrameType
 from typing import Callable, List, Optional, Union
 
@@ -126,6 +127,11 @@ class BackendRunner:
             _logger.info("Shutting down server...")
             shutdown_event.set()
             raise
+        except Exception as e:
+            _logger.critical(f"Unexpected error occurred when writing to connection file: {e}")
+            _logger.critical(traceback.format_exc())
+            _logger.info("Shutting down server")
+            shutdown_event.set()
         else:
             if on_connection_file_written:
                 callbacks = list(on_connection_file_written)

--- a/src/openjd/adaptor_runtime/_background/backend_runner.py
+++ b/src/openjd/adaptor_runtime/_background/backend_runner.py
@@ -83,7 +83,6 @@ class BackendRunner:
         if OSName.is_posix():  # pragma: is-windows
             server_path = SocketPaths.for_os().get_process_socket_path(
                 ".openjd_adaptor_runtime",
-                base_dir=os.getcwd(),
                 create_dir=True,
             )
         else:  # pragma: is-posix

--- a/src/openjd/adaptor_runtime/_background/frontend_runner.py
+++ b/src/openjd/adaptor_runtime/_background/frontend_runner.py
@@ -145,7 +145,7 @@ class FrontendRunner:
         bootstrap_log_path = os.path.join(
             bootstrap_log_dir, f"adaptor-runtime-background-bootstrap-{bootstrap_id}.log"
         )
-        args.extend(["--log-file", bootstrap_log_path])
+        args.extend(["--bootstrap-log-file", bootstrap_log_path])
 
         _logger.debug(f"Running process with args: {args}")
         bootstrap_output_path = os.path.join(

--- a/src/openjd/adaptor_runtime/_background/loaders.py
+++ b/src/openjd/adaptor_runtime/_background/loaders.py
@@ -38,11 +38,11 @@ class ConnectionSettingsFileLoader(ConnectionSettingsLoader):
             with open(self.file_path) as conn_file:
                 loaded_settings = json.load(conn_file)
         except OSError as e:
-            errmsg = f"Failed to open connection file: {e}"
+            errmsg = f"Failed to open connection file '{self.file_path}': {e}"
             _logger.error(errmsg)
             raise ConnectionSettingsLoadingError(errmsg) from e
         except json.JSONDecodeError as e:
-            errmsg = f"Failed to decode connection file: {e}"
+            errmsg = f"Failed to decode connection file '{self.file_path}': {e}"
             _logger.error(errmsg)
             raise ConnectionSettingsLoadingError(errmsg) from e
         return DataclassMapper(ConnectionSettings).map(loaded_settings)

--- a/src/openjd/adaptor_runtime/_background/loaders.py
+++ b/src/openjd/adaptor_runtime/_background/loaders.py
@@ -1,0 +1,69 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+from __future__ import annotations
+
+import abc
+import dataclasses
+import logging
+import json
+import os
+from pathlib import Path
+
+from .model import (
+    ConnectionSettings,
+    DataclassMapper,
+)
+
+_logger = logging.getLogger(__name__)
+
+
+class ConnectionSettingsLoadingError(Exception):
+    """Raised when the connection settings cannot be loaded"""
+
+    pass
+
+
+class ConnectionSettingsLoader(abc.ABC):
+    @abc.abstractmethod
+    def load(self) -> ConnectionSettings:
+        pass
+
+
+@dataclasses.dataclass
+class ConnectionSettingsFileLoader(ConnectionSettingsLoader):
+    file_path: Path
+
+    def load(self) -> ConnectionSettings:
+        try:
+            with open(self.file_path) as conn_file:
+                loaded_settings = json.load(conn_file)
+        except OSError as e:
+            errmsg = f"Failed to open connection file: {e}"
+            _logger.error(errmsg)
+            raise ConnectionSettingsLoadingError(errmsg) from e
+        except json.JSONDecodeError as e:
+            errmsg = f"Failed to decode connection file: {e}"
+            _logger.error(errmsg)
+            raise ConnectionSettingsLoadingError(errmsg) from e
+        return DataclassMapper(ConnectionSettings).map(loaded_settings)
+
+
+@dataclasses.dataclass
+class ConnectionSettingsEnvLoader(ConnectionSettingsLoader):
+    env_map: dict[str, tuple[str, bool]] = dataclasses.field(
+        default_factory=lambda: {"socket": ("OPENJD_ADAPTOR_SOCKET", True)}
+    )
+    """Mapping of environment variable to a tuple of ConnectionSettings attribute name, and whether it is required"""
+
+    def load(self) -> ConnectionSettings:
+        kwargs = {}
+        for attr_name, (env_name, required) in self.env_map.items():
+            env_val = os.environ.get(env_name)
+            if not env_val:
+                if required:
+                    raise ConnectionSettingsLoadingError(
+                        f"Required attribute '{attr_name}' does not have its corresponding environment variable '{env_name}' set"
+                    )
+            else:
+                kwargs[attr_name] = env_val
+        return ConnectionSettings(**kwargs)

--- a/src/openjd/adaptor_runtime/_background/server_response.py
+++ b/src/openjd/adaptor_runtime/_background/server_response.py
@@ -17,8 +17,8 @@ if TYPE_CHECKING:
     from .http_server import BackgroundHTTPServer
 
 
-from ..adaptors._adaptor_runner import _OPENJD_FAIL_STDOUT_PREFIX
 from .._http import HTTPResponse
+from .._utils._constants import _OPENJD_FAIL_STDOUT_PREFIX
 from .model import (
     AdaptorState,
     AdaptorStatus,

--- a/src/openjd/adaptor_runtime/_entrypoint.py
+++ b/src/openjd/adaptor_runtime/_entrypoint.py
@@ -112,7 +112,7 @@ class _ParsedArgs(Namespace):
     run_data: str
     path_mapping_rules: str
     connection_file: str | None
-    log_file: str | None
+    bootstrap_log_file: str | None
 
     # is-compatible args
     openjd_adaptor_cli_version: str | None
@@ -255,7 +255,11 @@ class EntryPoint:
         """
         parser, parsed_args = self._parse_args()
         log_config = self._init_loggers(
-            bootstrap_log_path=parsed_args.log_file if hasattr(parsed_args, "log_file") else None
+            bootstrap_log_path=(
+                parsed_args.bootstrap_log_file
+                if hasattr(parsed_args, "bootstrap_log_file")
+                else None
+            )
         )
 
         interface_version_info = self._get_version_info()
@@ -512,7 +516,7 @@ class EntryPoint:
 
         log_file = ArgumentParser(add_help=False)
         log_file.add_argument(
-            "--log-file",
+            "--bootstrap-log-file",
             help=_CLI_HELP_TEXT["log_file"],
             required=False,
         )

--- a/src/openjd/adaptor_runtime/_http/__init__.py
+++ b/src/openjd/adaptor_runtime/_http/__init__.py
@@ -1,6 +1,6 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 from .request_handler import HTTPResponse, RequestHandler, ResourceRequestHandler
-from .sockets import SocketDirectories
+from .sockets import SocketPaths
 
-__all__ = ["HTTPResponse", "RequestHandler", "ResourceRequestHandler", "SocketDirectories"]
+__all__ = ["HTTPResponse", "RequestHandler", "ResourceRequestHandler", "SocketPaths"]

--- a/src/openjd/adaptor_runtime/_http/sockets.py
+++ b/src/openjd/adaptor_runtime/_http/sockets.py
@@ -6,7 +6,6 @@ import abc
 import os
 import stat
 import tempfile
-import uuid
 
 from .._osname import OSName
 from .exceptions import (
@@ -108,8 +107,10 @@ class SocketPaths(abc.ABC):
 
         def gen_socket_path(dir: str, base_name: str):
             name = base_name
+            i = 0
             while os.path.exists(os.path.join(dir, name)):
-                name = f"{base_name}_{str(uuid.uuid4()).replace('-', '')}"
+                i += 1
+                name = f"{base_name}_{i}"
             return os.path.join(dir, name)
 
         reasons: list[str] = []

--- a/src/openjd/adaptor_runtime/_http/sockets.py
+++ b/src/openjd/adaptor_runtime/_http/sockets.py
@@ -6,6 +6,7 @@ import abc
 import os
 import stat
 import tempfile
+import uuid
 
 from .._osname import OSName
 from .exceptions import (
@@ -106,11 +107,9 @@ class SocketPaths(abc.ABC):
             return path
 
         def gen_socket_path(dir: str, base_name: str):
-            i = 0
             name = base_name
             while os.path.exists(os.path.join(dir, name)):
-                i = i + 1
-                name = f"{base_name}_{i}"
+                name = f"{base_name}_{str(uuid.uuid4()).replace('-', '')}"
             return os.path.join(dir, name)
 
         rel_path = os.path.join(".openjd", "adaptors", "sockets")

--- a/src/openjd/adaptor_runtime/_http/sockets.py
+++ b/src/openjd/adaptor_runtime/_http/sockets.py
@@ -112,15 +112,11 @@ class SocketPaths(abc.ABC):
                 name = f"{base_name}_{str(uuid.uuid4()).replace('-', '')}"
             return os.path.join(dir, name)
 
-        rel_path = os.path.join(".openjd", "adaptors", "sockets")
-        if namespace:
-            rel_path = os.path.join(rel_path, namespace)
-
         reasons: list[str] = []
 
         if base_dir:
             # Only try to use the provided base directory
-            socket_dir = os.path.join(base_dir, rel_path)
+            socket_dir = base_dir if not namespace else os.path.join(base_dir, namespace)
             socket_path = gen_socket_path(socket_dir, base_socket_name)
             try:
                 self.verify_socket_path(socket_path)
@@ -132,6 +128,10 @@ class SocketPaths(abc.ABC):
                 mkdir(socket_dir)
                 return socket_path
         else:
+            rel_path = os.path.join(".openjd", "adaptors", "sockets")
+            if namespace:
+                rel_path = os.path.join(rel_path, namespace)
+
             # First try home directory
             home_dir = os.path.expanduser("~")
             socket_dir = os.path.join(home_dir, rel_path)
@@ -195,13 +195,12 @@ class LinuxSocketPaths(SocketPaths):
     _socket_name_max_length = 108 - 1
 
     def verify_socket_path(self, path: str) -> None:
-        socket_name = os.path.basename(path)
-        socket_name_length = len(socket_name.encode("utf-8"))
-        if socket_name_length > self._socket_name_max_length:
+        path_length = len(path.encode("utf-8"))
+        if path_length > self._socket_name_max_length:
             raise NonvalidSocketPathException(
                 "Socket name too long. The maximum allowed size is "
                 f"{self._socket_name_max_length} bytes, but the name has a size of "
-                f"{socket_name_length}: {socket_name}"
+                f"{path_length}: {path}"
             )
 
 
@@ -216,13 +215,12 @@ class MacOSSocketPaths(SocketPaths):
     _socket_name_max_length = 104 - 1
 
     def verify_socket_path(self, path: str) -> None:
-        socket_name = os.path.basename(path)
-        socket_name_length = len(socket_name.encode("utf-8"))
-        if socket_name_length > self._socket_name_max_length:
+        path_length = len(path.encode("utf-8"))
+        if path_length > self._socket_name_max_length:
             raise NonvalidSocketPathException(
                 "Socket name too long. The maximum allowed size is "
                 f"{self._socket_name_max_length} bytes, but the name has a size of "
-                f"{socket_name_length}: {socket_name}"
+                f"{path_length}: {path}"
             )
 
 

--- a/src/openjd/adaptor_runtime/_utils/_constants.py
+++ b/src/openjd/adaptor_runtime/_utils/_constants.py
@@ -1,0 +1,13 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+import re
+
+_OPENJD_LOG_PATTERN = r"^openjd_\S+: "
+_OPENJD_LOG_REGEX = re.compile(_OPENJD_LOG_PATTERN)
+
+_OPENJD_FAIL_STDOUT_PREFIX = "openjd_fail: "
+_OPENJD_PROGRESS_STDOUT_PREFIX = "openjd_progress: "
+_OPENJD_STATUS_STDOUT_PREFIX = "openjd_status: "
+_OPENJD_ENV_STDOUT_PREFIX = "openjd_env: "
+
+_OPENJD_ADAPTOR_SOCKET_ENV = "OPENJD_ADAPTOR_SOCKET"

--- a/src/openjd/adaptor_runtime/_utils/_logging.py
+++ b/src/openjd/adaptor_runtime/_utils/_logging.py
@@ -6,9 +6,6 @@ from typing import (
     Optional,
 )
 
-_OPENJD_LOG_PATTERN = r"^openjd_\S+: "
-_OPENJD_LOG_REGEX = re.compile(_OPENJD_LOG_PATTERN)
-
 
 class ConditionalFormatter(logging.Formatter):
     """

--- a/src/openjd/adaptor_runtime/_utils/_secure_open.py
+++ b/src/openjd/adaptor_runtime/_utils/_secure_open.py
@@ -81,7 +81,7 @@ def get_file_owner_in_windows(filepath: "StrOrBytesPath") -> str:  # pragma: is-
     Returns:
         str: A string in the format 'DOMAIN\\Username' representing the file's owner.
     """
-    sd = win32security.GetFileSecurity(filepath, win32security.OWNER_SECURITY_INFORMATION)
+    sd = win32security.GetFileSecurity(str(filepath), win32security.OWNER_SECURITY_INFORMATION)
     owner_sid = sd.GetSecurityDescriptorOwner()
     name, domain, _ = win32security.LookupAccountSid(None, owner_sid)
     return f"{domain}\\{name}"
@@ -108,13 +108,13 @@ def set_file_permissions_in_windows(filepath: "StrOrBytesPath") -> None:  # prag
     dacl.AddAccessAllowedAce(win32security.ACL_REVISION, win32con.DELETE, user_sid)
 
     # Apply the DACL to the file
-    sd = win32security.GetFileSecurity(filepath, win32security.DACL_SECURITY_INFORMATION)
+    sd = win32security.GetFileSecurity(str(filepath), win32security.DACL_SECURITY_INFORMATION)
     sd.SetSecurityDescriptorDacl(
         1,  # A flag that indicates the presence of a DACL in the security descriptor.
         dacl,  # An ACL structure that specifies the DACL for the security descriptor.
         0,  # Don't retrieve the default DACL
     )
-    win32security.SetFileSecurity(filepath, win32security.DACL_SECURITY_INFORMATION, sd)
+    win32security.SetFileSecurity(str(filepath), win32security.DACL_SECURITY_INFORMATION, sd)
 
 
 def _get_flags_from_mode_str(open_mode: str) -> int:

--- a/src/openjd/adaptor_runtime/adaptors/_adaptor_runner.py
+++ b/src/openjd/adaptor_runtime/adaptors/_adaptor_runner.py
@@ -6,12 +6,11 @@ import logging
 
 from ._adaptor_states import AdaptorState, AdaptorStates
 from ._base_adaptor import BaseAdaptor as BaseAdaptor
+from .._utils._constants import _OPENJD_FAIL_STDOUT_PREFIX
 
 __all__ = ["AdaptorRunner"]
 
 _logger = logging.getLogger(__name__)
-
-_OPENJD_FAIL_STDOUT_PREFIX: str = "openjd_fail: "
 
 
 class AdaptorRunner(AdaptorStates):

--- a/src/openjd/adaptor_runtime/adaptors/_base_adaptor.py
+++ b/src/openjd/adaptor_runtime/adaptors/_base_adaptor.py
@@ -13,6 +13,7 @@ from typing import Generic
 from typing import Type
 from typing import TypeVar
 
+from .._utils._constants import _OPENJD_PROGRESS_STDOUT_PREFIX, _OPENJD_STATUS_STDOUT_PREFIX
 from .configuration import AdaptorConfiguration, ConfigurationManager
 from .configuration._configuration_manager import (
     create_adaptor_configuration_manager as create_adaptor_configuration_manager,
@@ -54,8 +55,8 @@ class BaseAdaptor(AdaptorStates, Generic[_T]):
     Base class for adaptors.
     """
 
-    _OPENJD_PROGRESS_STDOUT_PREFIX: str = "openjd_progress: "
-    _OPENJD_STATUS_STDOUT_PREFIX: str = "openjd_status: "
+    _OPENJD_PROGRESS_STDOUT_PREFIX: str = _OPENJD_PROGRESS_STDOUT_PREFIX
+    _OPENJD_STATUS_STDOUT_PREFIX: str = _OPENJD_STATUS_STDOUT_PREFIX
 
     def __init__(
         self,

--- a/src/openjd/adaptor_runtime/application_ipc/_adaptor_server.py
+++ b/src/openjd/adaptor_runtime/application_ipc/_adaptor_server.py
@@ -8,7 +8,7 @@ import warnings
 from socketserver import UnixStreamServer  # type: ignore[attr-defined]
 from typing import TYPE_CHECKING
 
-from .._http import SocketDirectories
+from .._http import SocketPaths
 from ._http_request_handler import AdaptorHTTPRequestHandler
 
 if TYPE_CHECKING:  # pragma: no cover because pytest will think we should test for this.
@@ -32,8 +32,14 @@ class AdaptorServer(UnixStreamServer):
         self,
         actions_queue: ActionsQueue,
         adaptor: BaseAdaptor,
+        *,
+        working_dir: str | None = None,
     ) -> None:  # pragma: no cover
-        socket_path = SocketDirectories.for_os().get_process_socket_path("dcc", create_dir=True)
+        socket_path = SocketPaths.for_os().get_process_socket_path(
+            "dcc",
+            base_dir=working_dir,
+            create_dir=True,
+        )
         super().__init__(socket_path, AdaptorHTTPRequestHandler)
 
         self.actions_queue = actions_queue

--- a/src/openjd/adaptor_runtime/application_ipc/_adaptor_server.py
+++ b/src/openjd/adaptor_runtime/application_ipc/_adaptor_server.py
@@ -34,8 +34,7 @@ class AdaptorServer(UnixStreamServer):
         adaptor: BaseAdaptor,
     ) -> None:  # pragma: no cover
         socket_path = SocketPaths.for_os().get_process_socket_path(
-            "dcc",
-            base_dir=os.getcwd(),
+            ".openjd_adaptor_server",
             create_dir=True,
         )
         super().__init__(socket_path, AdaptorHTTPRequestHandler)

--- a/src/openjd/adaptor_runtime/application_ipc/_adaptor_server.py
+++ b/src/openjd/adaptor_runtime/application_ipc/_adaptor_server.py
@@ -32,12 +32,10 @@ class AdaptorServer(UnixStreamServer):
         self,
         actions_queue: ActionsQueue,
         adaptor: BaseAdaptor,
-        *,
-        working_dir: str | None = None,
     ) -> None:  # pragma: no cover
         socket_path = SocketPaths.for_os().get_process_socket_path(
             "dcc",
-            base_dir=working_dir,
+            base_dir=os.getcwd(),
             create_dir=True,
         )
         super().__init__(socket_path, AdaptorHTTPRequestHandler)

--- a/src/openjd/adaptor_runtime/application_ipc/_win_adaptor_server.py
+++ b/src/openjd/adaptor_runtime/application_ipc/_win_adaptor_server.py
@@ -26,7 +26,18 @@ class WinAdaptorServer(NamedPipeServer):
     actions_queue: ActionsQueue
     adaptor: BaseAdaptor
 
-    def __init__(self, actions_queue: ActionsQueue, adaptor: BaseAdaptor) -> None:
+    def __init__(
+        self,
+        actions_queue: ActionsQueue,
+        adaptor: BaseAdaptor,
+        *,
+        # TODO: Remove this
+        # The "working_dir" parameter was added to "AdaptorServer", so need to add it here as well.
+        # This is a temporary workaround due to how this class is used/exposed. In __init__.py,
+        # this class "replaces" the "AdaptorServer" class on Windows so the calling code does not
+        # even know it is instantiating a completely different class on Windows.
+        working_dir: str | None = None,
+    ) -> None:
         """
         Adaptor Server class in Windows.
 

--- a/src/openjd/adaptor_runtime/application_ipc/_win_adaptor_server.py
+++ b/src/openjd/adaptor_runtime/application_ipc/_win_adaptor_server.py
@@ -30,13 +30,6 @@ class WinAdaptorServer(NamedPipeServer):
         self,
         actions_queue: ActionsQueue,
         adaptor: BaseAdaptor,
-        *,
-        # TODO: Remove this
-        # The "working_dir" parameter was added to "AdaptorServer", so need to add it here as well.
-        # This is a temporary workaround due to how this class is used/exposed. In __init__.py,
-        # this class "replaces" the "AdaptorServer" class on Windows so the calling code does not
-        # even know it is instantiating a completely different class on Windows.
-        working_dir: str | None = None,
     ) -> None:
         """
         Adaptor Server class in Windows.

--- a/test/openjd/adaptor_runtime/integ/AdaptorExample/adaptor.py
+++ b/test/openjd/adaptor_runtime/integ/AdaptorExample/adaptor.py
@@ -3,7 +3,6 @@
 import logging
 import os
 import sys
-import tempfile
 import threading
 import time
 
@@ -47,14 +46,12 @@ class AdaptorExample(Adaptor):
         # execution.
         _logger.info("on_start")
 
-        self.working_dir = tempfile.TemporaryDirectory()
         # Initialize the server thread to manage actions
         self.server = AdaptorServer(
             # actions_queue will be used for storing the actions. In the client application, it will keep polling the
             # actions from this queue and run actions
             actions_queue=self.actions,
             adaptor=self,
-            working_dir=self.working_dir.name,
         )
         # The server will keep running until `stop` is called
         self.server_thread = threading.Thread(
@@ -159,9 +156,6 @@ class AdaptorExample(Adaptor):
             self.server_thread.join(timeout=5)
             if self.server_thread.is_alive():
                 _logger.error("Failed to shutdown the AdaptorExample server")
-
-        if hasattr(self, "working_dir"):
-            self.working_dir.cleanup()
 
     def on_cancel(self):
         """

--- a/test/openjd/adaptor_runtime/integ/AdaptorExample/adaptor.py
+++ b/test/openjd/adaptor_runtime/integ/AdaptorExample/adaptor.py
@@ -3,6 +3,7 @@
 import logging
 import os
 import sys
+import tempfile
 import threading
 import time
 
@@ -45,12 +46,15 @@ class AdaptorExample(Adaptor):
         # This example initializes a server thread to interact with a client application, showing command exchange and
         # execution.
         _logger.info("on_start")
+
+        self.working_dir = tempfile.TemporaryDirectory()
         # Initialize the server thread to manage actions
         self.server = AdaptorServer(
             # actions_queue will be used for storing the actions. In the client application, it will keep polling the
             # actions from this queue and run actions
             actions_queue=self.actions,
             adaptor=self,
+            working_dir=self.working_dir.name,
         )
         # The server will keep running until `stop` is called
         self.server_thread = threading.Thread(
@@ -155,6 +159,9 @@ class AdaptorExample(Adaptor):
             self.server_thread.join(timeout=5)
             if self.server_thread.is_alive():
                 _logger.error("Failed to shutdown the AdaptorExample server")
+
+        if hasattr(self, "working_dir"):
+            self.working_dir.cleanup()
 
     def on_cancel(self):
         """

--- a/test/openjd/adaptor_runtime/integ/background/test_background_mode.py
+++ b/test/openjd/adaptor_runtime/integ/background/test_background_mode.py
@@ -262,6 +262,61 @@ class TestDaemonMode:
         # THEN
         assert f"Received ACK for chunk: {response.output.id}" in new_response.output.output
 
+    @pytest.mark.skipif(not OSName.is_posix(), reason="Posix-specific test")
+    def test_init_uses_working_dir(
+        self,
+        tmp_path: pathlib.Path,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        backend_proc = None
+        conn_settings = None
+        try:
+            # GIVEN
+            caplog.set_level(0)
+            working_dir = tmp_path / "working_dir"
+            working_dir.mkdir()
+            frontend = FrontendRunner(working_dir=str(working_dir), timeout_s=5.0)
+
+            # WHEN
+            frontend.init(sys.modules[AdaptorExample.__module__])
+
+            # THEN
+
+            # Connection file should be in the working dir
+            connection_file = working_dir / "connection.json"
+            conn_settings = _load_connection_settings(str(connection_file))
+
+            # Backend process started successfully
+            match = re.search("Started backend process. PID: ([0-9]+)", caplog.text)
+            assert match is not None
+            pid = int(match.group(1))
+            backend_proc = psutil.Process(pid)
+
+            # Unix socket matches connection file and is also in the working dir
+            assert any(
+                [
+                    conn.laddr == conn_settings.socket
+                    for conn in backend_proc.connections(kind="unix")
+                ]
+            )
+            assert conn_settings.socket.startswith(str(working_dir))
+
+        finally:
+            if backend_proc:
+                try:
+                    backend_proc.kill()
+                except psutil.NoSuchProcess:
+                    pass  # Already stopped
+
+            # We don't need to call the `remove` for the NamedPipe server.
+            # NamedPipe servers are managed by Named Pipe File System it is not a regular file.
+            # Once all handles are closed, the system automatically cleans up the named pipe.
+            if OSName.is_posix() and conn_settings:
+                try:
+                    os.remove(conn_settings.socket)
+                except FileNotFoundError:
+                    pass  # Already deleted
+
     class TestAuthentication:
         """
         Tests for background mode authentication.

--- a/test/openjd/adaptor_runtime/integ/background/test_background_mode.py
+++ b/test/openjd/adaptor_runtime/integ/background/test_background_mode.py
@@ -72,7 +72,7 @@ class TestDaemonMode:
         caplog: pytest.LogCaptureFixture,
     ) -> Generator[tuple[FrontendRunner, psutil.Process], None, None]:
         caplog.set_level(0)
-        frontend = FrontendRunner(connection_file_path, timeout_s=5.0)
+        frontend = FrontendRunner(connection_file_path=connection_file_path, timeout_s=5.0)
         frontend.init(sys.modules[AdaptorExample.__module__])
         conn_settings = _load_connection_settings(connection_file_path)
 

--- a/test/openjd/adaptor_runtime/integ/test_integration_entrypoint.py
+++ b/test/openjd/adaptor_runtime/integ/test_integration_entrypoint.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import pathlib
 import os
 import re
 import sys
@@ -32,7 +33,7 @@ class TestCommandAdaptorRun:
     """
 
     def test_runs_command_adaptor(
-        self, capfd: pytest.CaptureFixture, caplog: pytest.LogCaptureFixture
+        self, capfd: pytest.CaptureFixture, caplog: pytest.LogCaptureFixture, tmp_path: pathlib.Path
     ):
         # GIVEN
         caplog.set_level(INFO)

--- a/test/openjd/adaptor_runtime/unit/background/test_backend_runner.py
+++ b/test/openjd/adaptor_runtime/unit/background/test_backend_runner.py
@@ -67,7 +67,7 @@ class TestBackendRunner:
     ):
         # GIVEN
         caplog.set_level("DEBUG")
-        conn_dir = "/path/to/conn_dir"
+        conn_dir = os.path.join(os.sep, "path", "to", "conn_dir")
         connection_settings = {"socket": socket_path}
         adaptor_runner = Mock()
         runner = BackendRunner(adaptor_runner, working_dir=conn_dir)
@@ -93,7 +93,7 @@ class TestBackendRunner:
         )
         mock_thread.assert_called_once()
         mock_thread.return_value.start.assert_called_once()
-        conn_file_path = f"{conn_dir}/connection.json"
+        conn_file_path = os.path.join(conn_dir, "connection.json")
         open_mock.assert_called_once_with(conn_file_path, open_mode="w")
         mock_json_dump.assert_called_once_with(
             ConnectionSettings(socket_path),
@@ -115,7 +115,10 @@ class TestBackendRunner:
         caplog.set_level("DEBUG")
         exc = Exception()
         mock_server_cls.side_effect = exc
-        runner = BackendRunner(Mock(), connection_file_path="/tmp/connection.json")
+        runner = BackendRunner(
+            Mock(),
+           connection_file_path=os.path.join(os.path.sep, "tmp", "connection.json"),
+        )
 
         # WHEN
         with pytest.raises(Exception) as raised_exc:
@@ -145,7 +148,7 @@ class TestBackendRunner:
         caplog.set_level("DEBUG")
         err = OSError()
         open_mock.side_effect = err
-        conn_dir = "/path/to/conn_dir"
+        conn_dir = os.path.join(os.sep, "path", "to", "conn_dir")
         adaptor_runner = Mock()
         runner = BackendRunner(adaptor_runner, working_dir=conn_dir)
 
@@ -165,7 +168,7 @@ class TestBackendRunner:
         ]
         mock_thread.assert_called_once()
         mock_thread.return_value.start.assert_called_once()
-        conn_file_path = f"{conn_dir}/connection.json"
+        conn_file_path = os.path.join(conn_dir, "connection.json")
         open_mock.assert_called_once_with(conn_file_path, open_mode="w")
         mock_thread.return_value.join.assert_called_once()
         if OSName.is_posix():
@@ -180,7 +183,7 @@ class TestBackendRunner:
         # as expected.
 
         # GIVEN
-        conn_file_path = "/path/to/conn_file"
+        conn_file_path = os.path.join(os.sep, "path", "to", "conn_file")
         adaptor_runner = Mock()
         runner = BackendRunner(adaptor_runner, connection_file_path=conn_file_path)
         server_mock = MagicMock()

--- a/test/openjd/adaptor_runtime/unit/background/test_backend_runner.py
+++ b/test/openjd/adaptor_runtime/unit/background/test_backend_runner.py
@@ -117,7 +117,7 @@ class TestBackendRunner:
         mock_server_cls.side_effect = exc
         runner = BackendRunner(
             Mock(),
-           connection_file_path=os.path.join(os.path.sep, "tmp", "connection.json"),
+            connection_file_path=os.path.join(os.path.sep, "tmp", "connection.json"),
         )
 
         # WHEN

--- a/test/openjd/adaptor_runtime/unit/background/test_frontend_runner.py
+++ b/test/openjd/adaptor_runtime/unit/background/test_frontend_runner.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import http.client as http_client
 import json
+import os
 import re
 import signal
 import subprocess
@@ -806,7 +807,7 @@ class TestFrontendRunner:
             # as expected.
 
             # GIVEN
-            conn_file_path = "/path/to/conn_file"
+            conn_file_path = os.path.join(os.sep, "path", "to", "conn_file")
             runner = FrontendRunner(connection_file_path=conn_file_path)
 
             # WHEN

--- a/test/openjd/adaptor_runtime/unit/background/test_frontend_runner.py
+++ b/test/openjd/adaptor_runtime/unit/background/test_frontend_runner.py
@@ -9,28 +9,27 @@ import re
 import signal
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 from types import ModuleType
 from typing import Generator, Optional
-from unittest.mock import MagicMock, PropertyMock, call, mock_open, patch
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 
-import openjd.adaptor_runtime._background.frontend_runner as frontend_runner
+from openjd.adaptor_runtime._background import frontend_runner
 from openjd.adaptor_runtime._osname import OSName
 from openjd.adaptor_runtime.adaptors import AdaptorState
 from openjd.adaptor_runtime._background.frontend_runner import (
     AdaptorFailedException,
     FrontendRunner,
     HTTPError,
-    _load_connection_settings,
     _wait_for_file,
 )
 from openjd.adaptor_runtime._background.model import (
     AdaptorStatus,
     BufferedOutput,
     ConnectionSettings,
-    DataclassMapper,
     HeartbeatResponse,
 )
 
@@ -44,11 +43,21 @@ class TestFrontendRunner:
     def server_name(self) -> str:
         return "/path/to/socket" if OSName.is_posix() else r"\\.\pipe\TestPipe"
 
+    @pytest.fixture
+    def connection_settings(self, server_name: str) -> ConnectionSettings:
+        return ConnectionSettings(server_name)
+
     @pytest.fixture(autouse=True)
-    def mock_connection_settings(self, server_name: str) -> Generator[MagicMock, None, None]:
-        with patch.object(FrontendRunner, "connection_settings", new_callable=PropertyMock) as mock:
-            mock.return_value = ConnectionSettings(server_name)
-            yield mock
+    def mock_connection_settings(
+        self, connection_settings: ConnectionSettings
+    ) -> Generator[None, None, None]:
+        with patch.object(
+            FrontendRunner,
+            "connection_settings",
+            return_value=connection_settings,
+            create=True,
+        ):
+            yield
 
     class TestInit:
         """
@@ -60,6 +69,51 @@ class TestFrontendRunner:
             with patch.object(frontend_runner, "open") as m:
                 yield m
 
+        @pytest.fixture(autouse=True)
+        def mock_path_exists(self) -> Generator[MagicMock, None, None]:
+            with patch.object(frontend_runner.Path, "exists") as m:
+                yield m
+
+        @pytest.fixture(autouse=True)
+        def mock_uuid(self) -> Generator[MagicMock, None, None]:
+            with patch.object(frontend_runner.uuid, "uuid4") as m:
+                yield m
+
+        @pytest.fixture(autouse=True)
+        def mock_gettempdir(self) -> Generator[MagicMock, None, None]:
+            with patch.object(frontend_runner.tempfile, "gettempdir") as m:
+                yield m
+
+        @pytest.fixture(autouse=True)
+        def mock_Popen(self) -> Generator[MagicMock, None, None]:
+            with patch.object(frontend_runner.subprocess, "Popen") as m:
+                yield m
+
+        @pytest.fixture(autouse=True)
+        def mock_wait_for_file(self) -> Generator[MagicMock, None, None]:
+            with patch.object(frontend_runner, "_wait_for_file") as m:
+                yield m
+
+        @pytest.fixture(autouse=True)
+        def mock_heartbeat(self) -> Generator[MagicMock, None, None]:
+            with patch.object(frontend_runner.FrontendRunner, "_heartbeat") as m:
+                yield m
+
+        @pytest.fixture(autouse=True)
+        def mock_sys_argv(self) -> Generator[MagicMock, None, None]:
+            with patch.object(frontend_runner.sys, "argv", return_value=[]) as m:
+                yield m
+
+        @pytest.fixture(autouse=True)
+        def mock_sys_executable(self) -> Generator[MagicMock, None, None]:
+            with patch.object(frontend_runner.sys, "executable", return_value="executable") as m:
+                yield m
+
+        @pytest.fixture(autouse=True)
+        def mock_connection_settings_file_load(self) -> Generator[MagicMock, None, None]:
+            with patch.object(frontend_runner.ConnectionSettingsFileLoader, "load") as m:
+                yield m
+
         @pytest.mark.parametrize(
             argnames="reentry_exe",
             argvalues=[
@@ -67,21 +121,12 @@ class TestFrontendRunner:
                 (Path("reeentry_exe_value"),),
             ],
         )
-        @patch.object(frontend_runner.uuid, "uuid4", return_value="uuid")
-        @patch.object(frontend_runner.sys, "argv")
-        @patch.object(frontend_runner.sys, "executable")
-        @patch.object(frontend_runner.json, "dumps")
-        @patch.object(FrontendRunner, "_heartbeat")
-        @patch.object(frontend_runner, "_wait_for_file")
-        @patch.object(frontend_runner.subprocess, "Popen")
-        @patch.object(frontend_runner.os.path, "exists")
         def test_initializes_backend_process(
             self,
-            mock_exists: MagicMock,
+            mock_path_exists: MagicMock,
             mock_Popen: MagicMock,
             mock_wait_for_file: MagicMock,
             mock_heartbeat: MagicMock,
-            mock_json_dumps: MagicMock,
             mock_sys_executable: MagicMock,
             mock_sys_argv: MagicMock,
             mock_uuid: MagicMock,
@@ -91,21 +136,26 @@ class TestFrontendRunner:
         ):
             # GIVEN
             caplog.set_level("DEBUG")
-            mock_json_dumps.return_value = "test"
-            mock_exists.return_value = False
+            mock_path_exists.return_value = False
             pid = 123
             mock_Popen.return_value.pid = pid
             mock_sys_executable.return_value = "executable"
             mock_sys_argv.return_value = []
             adaptor_module = ModuleType("")
             adaptor_module.__package__ = "package"
-            conn_file_path = "/path"
             init_data = {"init": "data"}
             path_mapping_data: dict = {}
-            runner = FrontendRunner(connection_file_path=conn_file_path)
+            connection_file_path = Path("connection.test")
+            runner = FrontendRunner()
 
             # WHEN
-            runner.init(adaptor_module, init_data, path_mapping_data, reentry_exe)
+            runner.init(
+                adaptor_module=adaptor_module,
+                connection_file_path=connection_file_path,
+                init_data=init_data,
+                path_mapping_data=path_mapping_data,
+                reentry_exe=reentry_exe,
+            )
 
             # THEN
             assert all(
@@ -117,7 +167,7 @@ class TestFrontendRunner:
                     "Connected successfully",
                 ]
             )
-            mock_exists.assert_called_once_with(conn_file_path)
+            mock_path_exists.assert_called_once_with()
             if reentry_exe is None:
                 expected_args = [
                     sys.executable,
@@ -130,7 +180,7 @@ class TestFrontendRunner:
                     "--path-mapping-rules",
                     json.dumps(path_mapping_data),
                     "--connection-file",
-                    conn_file_path,
+                    str(connection_file_path),
                 ]
             else:
                 expected_args = [
@@ -142,13 +192,13 @@ class TestFrontendRunner:
                     "--path-mapping-rules",
                     json.dumps(path_mapping_data),
                     "--connection-file",
-                    conn_file_path,
+                    str(connection_file_path),
                 ]
             expected_args.extend(
                 [
                     "--log-file",
                     os.path.join(
-                        os.path.dirname(conn_file_path),
+                        tempfile.gettempdir(),
                         f"adaptor-runtime-background-bootstrap-{mock_uuid.return_value}.log",
                     ),
                 ]
@@ -162,50 +212,53 @@ class TestFrontendRunner:
                 stdout=open_mock.return_value,
                 stderr=open_mock.return_value,
             )
-            mock_wait_for_file.assert_called_once_with(conn_file_path, timeout_s=5)
+            mock_wait_for_file.assert_called_once_with(str(connection_file_path), timeout_s=5)
             mock_heartbeat.assert_called_once()
 
         def test_raises_when_adaptor_module_not_package(self):
             # GIVEN
             adaptor_module = ModuleType("")
             adaptor_module.__package__ = None
-            runner = FrontendRunner(connection_file_path="/tmp/connection.json")
+            runner = FrontendRunner()
 
             # WHEN
             with pytest.raises(Exception) as raised_exc:
-                runner.init(adaptor_module)
+                runner.init(
+                    adaptor_module=adaptor_module,
+                    connection_file_path="/path",
+                )
 
             # THEN
             assert raised_exc.match(f"Adaptor module is not a package: {adaptor_module}")
 
-        @patch.object(frontend_runner.os.path, "exists")
         def test_raises_when_connection_file_exists(
             self,
-            mock_exists: MagicMock,
+            mock_path_exists: MagicMock,
         ):
             # GIVEN
-            mock_exists.return_value = True
+            mock_path_exists.return_value = True
             adaptor_module = ModuleType("")
             adaptor_module.__package__ = "package"
-            conn_file_path = "/path"
-            runner = FrontendRunner(connection_file_path=conn_file_path)
+            conn_file_path = Path("/path")
+            runner = FrontendRunner()
 
             # WHEN
             with pytest.raises(FileExistsError) as raised_err:
-                runner.init(adaptor_module)
+                runner.init(
+                    adaptor_module=adaptor_module,
+                    connection_file_path=conn_file_path,
+                )
 
             # THEN
             assert raised_err.match(
                 "Cannot init a new backend process with an existing connection file at: "
-                + conn_file_path
+                + str(conn_file_path)
             )
-            mock_exists.assert_called_once_with(conn_file_path)
+            mock_path_exists.assert_called_once_with()
 
-        @patch.object(frontend_runner.subprocess, "Popen")
-        @patch.object(frontend_runner.os.path, "exists")
         def test_raises_when_failed_to_create_backend_process(
             self,
-            mock_exists: MagicMock,
+            mock_path_exists: MagicMock,
             mock_Popen: MagicMock,
             caplog: pytest.LogCaptureFixture,
         ):
@@ -213,15 +266,18 @@ class TestFrontendRunner:
             caplog.set_level("DEBUG")
             exc = Exception()
             mock_Popen.side_effect = exc
-            mock_exists.return_value = False
+            mock_path_exists.return_value = False
             adaptor_module = ModuleType("")
             adaptor_module.__package__ = "package"
-            conn_file_path = "/path"
-            runner = FrontendRunner(connection_file_path=conn_file_path)
+            conn_file_path = Path("/path")
+            runner = FrontendRunner()
 
             # WHEN
             with pytest.raises(Exception) as raised_exc:
-                runner.init(adaptor_module)
+                runner.init(
+                    adaptor_module=adaptor_module,
+                    connection_file_path=conn_file_path,
+                )
 
             # THEN
             assert raised_exc.value is exc
@@ -232,15 +288,12 @@ class TestFrontendRunner:
                     "Failed to initialize backend process: ",
                 ]
             )
-            mock_exists.assert_called_once_with(conn_file_path)
+            mock_path_exists.assert_called_once_with()
             mock_Popen.assert_called_once()
 
-        @patch.object(frontend_runner, "_wait_for_file")
-        @patch.object(frontend_runner.subprocess, "Popen")
-        @patch.object(frontend_runner.os.path, "exists")
         def test_raises_when_connection_file_wait_times_out(
             self,
-            mock_exists: MagicMock,
+            mock_path_exists: MagicMock,
             mock_Popen: MagicMock,
             mock_wait_for_file: MagicMock,
             caplog: pytest.LogCaptureFixture,
@@ -249,17 +302,20 @@ class TestFrontendRunner:
             caplog.set_level("DEBUG")
             err = TimeoutError()
             mock_wait_for_file.side_effect = err
-            mock_exists.return_value = False
+            mock_path_exists.return_value = False
             pid = 123
             mock_Popen.return_value.pid = pid
             adaptor_module = ModuleType("")
             adaptor_module.__package__ = "package"
-            conn_file_path = "/path"
-            runner = FrontendRunner(connection_file_path=conn_file_path)
+            conn_file_path = Path("/path")
+            runner = FrontendRunner()
 
             # WHEN
             with pytest.raises(TimeoutError) as raised_err:
-                runner.init(adaptor_module)
+                runner.init(
+                    adaptor_module=adaptor_module,
+                    connection_file_path=conn_file_path,
+                )
 
             # THEN
             assert raised_err.value is err
@@ -271,49 +327,58 @@ class TestFrontendRunner:
                     f"Backend process failed to write connection file in time at: {conn_file_path}",
                 ]
             )
-            mock_exists.assert_called_once_with(conn_file_path)
+            mock_path_exists.assert_called_once_with()
             mock_Popen.assert_called_once()
-            mock_wait_for_file.assert_called_once_with(conn_file_path, timeout_s=5)
+            mock_wait_for_file.assert_called_once_with(str(conn_file_path), timeout_s=5)
 
     class TestHeartbeat:
         """
         Tests for the FrontendRunner._heartbeat method
         """
 
-        @patch.object(frontend_runner.json, "load")
-        @patch.object(DataclassMapper, "map")
-        @patch.object(FrontendRunner, "_send_request")
+        @pytest.fixture(autouse=True)
+        def mock_json_load(self) -> Generator[MagicMock, None, None]:
+            with patch.object(frontend_runner.json, "load") as m:
+                yield m
+
+        @pytest.fixture(autouse=True)
+        def mock_dataclass_mapper_map(self) -> Generator[MagicMock, None, None]:
+            with patch.object(frontend_runner.DataclassMapper, "map") as m:
+                yield m
+
+        @pytest.fixture(autouse=True)
+        def mock_send_request(self) -> Generator[MagicMock, None, None]:
+            with patch.object(frontend_runner.FrontendRunner, "_send_request") as m:
+                yield m
+
         def test_sends_heartbeat(
             self,
             mock_send_request: MagicMock,
-            mock_map: MagicMock,
+            mock_dataclass_mapper_map: MagicMock,
             mock_json_load: MagicMock,
         ):
             # GIVEN
             if OSName.is_windows():
                 mock_send_request.return_value = {"body": '{"key1": "value1"}'}
             mock_response = mock_send_request.return_value
-            runner = FrontendRunner(connection_file_path="/tmp/connection.json")
+            runner = FrontendRunner()
 
             # WHEN
             response = runner._heartbeat()
 
             # THEN
-            assert response is mock_map.return_value
+            assert response is mock_dataclass_mapper_map.return_value
             if OSName.is_posix():
                 mock_json_load.assert_called_once_with(mock_response.fp)
-                mock_map.assert_called_once_with(mock_json_load.return_value)
+                mock_dataclass_mapper_map.assert_called_once_with(mock_json_load.return_value)
             else:
-                mock_map.assert_called_once_with({"key1": "value1"})
+                mock_dataclass_mapper_map.assert_called_once_with({"key1": "value1"})
             mock_send_request.assert_called_once_with("GET", "/heartbeat", params=None)
 
-        @patch.object(frontend_runner.json, "load")
-        @patch.object(DataclassMapper, "map")
-        @patch.object(FrontendRunner, "_send_request")
         def test_sends_heartbeat_with_ack_id(
             self,
             mock_send_request: MagicMock,
-            mock_map: MagicMock,
+            mock_dataclass_mapper_map: MagicMock,
             mock_json_load: MagicMock,
         ):
             # GIVEN
@@ -321,18 +386,18 @@ class TestFrontendRunner:
             if OSName.is_windows():
                 mock_send_request.return_value = {"body": '{"key1": "value1"}'}
             mock_response = mock_send_request.return_value
-            runner = FrontendRunner(connection_file_path="/tmp/connection.json")
+            runner = FrontendRunner()
 
             # WHEN
             response = runner._heartbeat(ack_id)
 
             # THEN
-            assert response is mock_map.return_value
+            assert response is mock_dataclass_mapper_map.return_value
             if OSName.is_posix():
                 mock_json_load.assert_called_once_with(mock_response.fp)
-                mock_map.assert_called_once_with(mock_json_load.return_value)
+                mock_dataclass_mapper_map.assert_called_once_with(mock_json_load.return_value)
             else:
-                mock_map.assert_called_once_with({"key1": "value1"})
+                mock_dataclass_mapper_map.assert_called_once_with({"key1": "value1"})
             mock_send_request.assert_called_once_with(
                 "GET", "/heartbeat", params={"ack_id": ack_id}
             )
@@ -364,9 +429,7 @@ class TestFrontendRunner:
             mock_event.wait = MagicMock()
             mock_event.is_set = MagicMock(return_value=False)
             heartbeat_interval = 1
-            runner = FrontendRunner(
-                connection_file_path="/tmp/connection.json", heartbeat_interval=heartbeat_interval
-            )
+            runner = FrontendRunner(heartbeat_interval=heartbeat_interval)
 
             # WHEN
             runner._heartbeat_until_state_complete(state)
@@ -395,7 +458,7 @@ class TestFrontendRunner:
                     failed=False,
                 ),
             ]
-            runner = FrontendRunner(connection_file_path="/tmp/connection.json")
+            runner = FrontendRunner()
 
             # WHEN
             with pytest.raises(AdaptorFailedException) as raised_exc:
@@ -413,7 +476,7 @@ class TestFrontendRunner:
         @patch.object(FrontendRunner, "_send_request")
         def test_sends_shutdown(self, mock_send_request: MagicMock):
             # GIVEN
-            runner = FrontendRunner(connection_file_path="/tmp/connection.json")
+            runner = FrontendRunner()
 
             # WHEN
             runner.shutdown()
@@ -435,7 +498,7 @@ class TestFrontendRunner:
         ):
             # GIVEN
             run_data = {"run": "data"}
-            runner = FrontendRunner(connection_file_path="/tmp/connection.json")
+            runner = FrontendRunner()
 
             # WHEN
             runner.run(run_data)
@@ -457,7 +520,7 @@ class TestFrontendRunner:
             mock_heartbeat_until_state_complete: MagicMock,
         ):
             # GIVEN
-            runner = FrontendRunner(connection_file_path="/tmp/connection.json")
+            runner = FrontendRunner()
 
             # WHEN
             runner.start()
@@ -479,7 +542,7 @@ class TestFrontendRunner:
             mock_heartbeat_until_state_complete: MagicMock,
         ):
             # GIVEN
-            runner = FrontendRunner(connection_file_path="/tmp/connection.json")
+            runner = FrontendRunner()
 
             # WHEN
             runner.stop()
@@ -499,7 +562,7 @@ class TestFrontendRunner:
             mock_send_request: MagicMock,
         ):
             # GIVEN
-            runner = FrontendRunner(connection_file_path="/tmp/connection.json")
+            runner = FrontendRunner()
 
             # WHEN
             runner.cancel()
@@ -525,12 +588,16 @@ class TestFrontendRunner:
                 yield mock
 
         @patch.object(frontend_runner.UnixHTTPConnection, "request")
-        def test_sends_request(self, mock_request: MagicMock, mock_getresponse: MagicMock):
+        def test_sends_request(
+            self,
+            mock_request: MagicMock,
+            mock_getresponse: MagicMock,
+            connection_settings: ConnectionSettings,
+        ):
             # GIVEN
             method = "GET"
             path = "/path"
-            conn_file_path = "/conn/file/path"
-            runner = FrontendRunner(connection_file_path=conn_file_path)
+            runner = FrontendRunner(connection_settings=connection_settings)
 
             # WHEN
             response = runner._send_request(method, path)
@@ -549,6 +616,7 @@ class TestFrontendRunner:
             self,
             mock_request: MagicMock,
             mock_getresponse: MagicMock,
+            connection_settings: ConnectionSettings,
             caplog: pytest.LogCaptureFixture,
         ):
             # GIVEN
@@ -556,8 +624,7 @@ class TestFrontendRunner:
             mock_getresponse.side_effect = exc
             method = "GET"
             path = "/path"
-            conn_file_path = "/conn/file/path"
-            runner = FrontendRunner(connection_file_path=conn_file_path)
+            runner = FrontendRunner(connection_settings=connection_settings)
 
             # WHEN
             with pytest.raises(http_client.HTTPException) as raised_exc:
@@ -579,6 +646,7 @@ class TestFrontendRunner:
             mock_request: MagicMock,
             mock_getresponse: MagicMock,
             mock_response: MagicMock,
+            connection_settings: ConnectionSettings,
             caplog: pytest.LogCaptureFixture,
         ):
             # GIVEN
@@ -586,8 +654,7 @@ class TestFrontendRunner:
             mock_response.reason = "Something went wrong"
             method = "GET"
             path = "/path"
-            conn_file_path = "/conn/file/path"
-            runner = FrontendRunner(connection_file_path=conn_file_path)
+            runner = FrontendRunner(connection_settings=connection_settings)
 
             # WHEN
             with pytest.raises(HTTPError) as raised_err:
@@ -607,13 +674,17 @@ class TestFrontendRunner:
             mock_getresponse.assert_called_once()
 
         @patch.object(frontend_runner.UnixHTTPConnection, "request")
-        def test_formats_query_string(self, mock_request: MagicMock, mock_getresponse: MagicMock):
+        def test_formats_query_string(
+            self,
+            mock_request: MagicMock,
+            mock_getresponse: MagicMock,
+            connection_settings: ConnectionSettings,
+        ):
             # GIVEN
             method = "GET"
             path = "/path"
-            conn_file_path = "/conn/file/path"
             params = {"first param": 1, "second_param": ["one", "two three"]}
-            runner = FrontendRunner(connection_file_path=conn_file_path)
+            runner = FrontendRunner(connection_settings=connection_settings)
 
             # WHEN
             response = runner._send_request(method, path, params=params)
@@ -628,13 +699,17 @@ class TestFrontendRunner:
             assert response is mock_getresponse.return_value
 
         @patch.object(frontend_runner.UnixHTTPConnection, "request")
-        def test_sends_body(self, mock_request: MagicMock, mock_getresponse: MagicMock):
+        def test_sends_body(
+            self,
+            mock_request: MagicMock,
+            mock_getresponse: MagicMock,
+            connection_settings: ConnectionSettings,
+        ):
             # GIVEN
             method = "GET"
             path = "/path"
-            conn_file_path = "/conn/file/path"
             json = {"the": "body"}
-            runner = FrontendRunner(connection_file_path=conn_file_path)
+            runner = FrontendRunner(connection_settings=connection_settings)
 
             # WHEN
             response = runner._send_request(method, path, json_body=json)
@@ -674,9 +749,8 @@ class TestFrontendRunner:
             # GIVEN
             method = "GET"
             path = "/path"
-            conn_file_path = r"C:\conn\file\path"
 
-            runner = FrontendRunner(connection_file_path=conn_file_path)
+            runner = FrontendRunner()
 
             # WHEN
             with patch.object(
@@ -707,8 +781,7 @@ class TestFrontendRunner:
             mock_read_from_pipe.side_effect = error_instance
             method = "GET"
             path = "/path"
-            conn_file_path = r"C:\conn\file\path"
-            runner = FrontendRunner(connection_file_path=conn_file_path)
+            runner = FrontendRunner()
 
             # WHEN
             with patch.object(
@@ -736,8 +809,7 @@ class TestFrontendRunner:
             # GIVEN
             method = "GET"
             path = "/path"
-            conn_file_path = r"C:\conn\file\path"
-            runner = FrontendRunner(connection_file_path=conn_file_path)
+            runner = FrontendRunner()
 
             # WHEN
             with patch.object(
@@ -773,9 +845,8 @@ class TestFrontendRunner:
             # GIVEN
             method = "GET"
             path = "/path"
-            conn_file_path = r"C:\conn\file\path"
             params = {"first param": 1, "second_param": ["one", "two three"]}
-            runner = FrontendRunner(connection_file_path=conn_file_path)
+            runner = FrontendRunner()
 
             # WHEN
             with patch.object(
@@ -803,9 +874,8 @@ class TestFrontendRunner:
             # GIVEN
             method = "GET"
             path = "/path"
-            conn_file_path = r"C:\conn\file\path"
             json_body = {"the": "body"}
-            runner = FrontendRunner(connection_file_path=conn_file_path)
+            runner = FrontendRunner()
 
             # WHEN
             with patch.object(
@@ -832,8 +902,7 @@ class TestFrontendRunner:
             # as expected.
 
             # GIVEN
-            conn_file_path = os.path.join(os.sep, "path", "to", "conn_file")
-            runner = FrontendRunner(connection_file_path=conn_file_path)
+            runner = FrontendRunner()
 
             # WHEN
             runner._sigint_handler(MagicMock(), MagicMock())
@@ -845,205 +914,6 @@ class TestFrontendRunner:
             else:
                 signal_mock.assert_any_call(signal.SIGBREAK, runner._sigint_handler)  # type: ignore[attr-defined]
             cancel_mock.assert_called_once()
-
-    class TestConnectionFileCompat:
-        @pytest.fixture(autouse=True)
-        def open_mock(self) -> Generator[MagicMock, None, None]:
-            with patch.object(frontend_runner, "open") as m:
-                yield m
-
-        @pytest.fixture(autouse=True)
-        def mock_uuid(self) -> Generator[MagicMock, None, None]:
-            with patch.object(frontend_runner.uuid, "uuid4", return_value="uuid") as m:
-                yield m
-
-        @pytest.mark.parametrize(
-            argnames=["connection_file", "working_dir"],
-            argvalues=[
-                ["path", "dir"],
-                [None, None],
-            ],
-            ids=["both provided", "neither provided"],
-        )
-        def test_rejects_not_exactly_one_of_connection_file_and_working_dir(
-            self,
-            connection_file: str | None,
-            working_dir: str | None,
-        ) -> None:
-            # GIVEN
-            with pytest.raises(RuntimeError) as raised_err:
-                # WHEN
-                FrontendRunner(
-                    connection_file_path=connection_file,
-                    working_dir=working_dir,
-                )
-
-            # THEN
-            assert (
-                f"Expected exactly one of 'connection_file_path' or 'working_dir', but got: connection_file_path={connection_file} working_dir={working_dir}"
-                == str(raised_err.value)
-            )
-
-        @patch.object(frontend_runner, "_wait_for_file")
-        @patch.object(frontend_runner.os.path, "exists", return_value=False)
-        @patch.object(frontend_runner.subprocess, "Popen")
-        def test_init_provides_connection_file_arg(
-            self,
-            mock_popen: MagicMock,
-            mock_exists: MagicMock,
-            mock_wait_for_file: MagicMock,
-            mock_uuid: MagicMock,
-            open_mock: MagicMock,
-        ) -> None:
-            # GIVEN
-            connection_file = os.path.join(os.sep, "path", "to", "connection.json")
-            runner = FrontendRunner(connection_file_path=connection_file)
-            adaptor_module = ModuleType("")
-            adaptor_module.__package__ = "package"
-
-            with patch.object(runner, "_heartbeat"):
-                # WHEN
-                runner.init(adaptor_module)
-
-            # THEN
-            mock_popen.assert_called_once_with(
-                [
-                    sys.executable,
-                    "-m",
-                    adaptor_module.__package__,
-                    "daemon",
-                    "_serve",
-                    "--init-data",
-                    json.dumps({}),
-                    "--path-mapping-rules",
-                    json.dumps({}),
-                    "--connection-file",
-                    connection_file,
-                    "--log-file",
-                    os.path.join(
-                        os.path.dirname(connection_file),
-                        f"adaptor-runtime-background-bootstrap-{mock_uuid.return_value}.log",
-                    ),
-                ],
-                shell=False,
-                close_fds=True,
-                start_new_session=True,
-                stdin=subprocess.DEVNULL,
-                stdout=open_mock.return_value,
-                stderr=open_mock.return_value,
-            )
-
-        @patch.object(frontend_runner, "_wait_for_file")
-        @patch.object(frontend_runner.os.path, "exists", return_value=False)
-        @patch.object(frontend_runner.subprocess, "Popen")
-        def test_init_provides_working_dir_arg(
-            self,
-            mock_popen: MagicMock,
-            mock_exists: MagicMock,
-            mock_wait_for_file: MagicMock,
-            mock_uuid: MagicMock,
-            open_mock: MagicMock,
-        ) -> None:
-            # GIVEN
-            working_dir = os.path.join(os.sep, "path", "to", "working")
-            runner = FrontendRunner(working_dir=working_dir)
-            adaptor_module = ModuleType("")
-            adaptor_module.__package__ = "package"
-
-            with patch.object(runner, "_heartbeat"):
-                # WHEN
-                runner.init(adaptor_module)
-
-            # THEN
-            mock_popen.assert_called_once_with(
-                [
-                    sys.executable,
-                    "-m",
-                    adaptor_module.__package__,
-                    "daemon",
-                    "_serve",
-                    "--init-data",
-                    json.dumps({}),
-                    "--path-mapping-rules",
-                    json.dumps({}),
-                    "--working-dir",
-                    working_dir,
-                    "--log-file",
-                    os.path.join(
-                        working_dir,
-                        f"adaptor-runtime-background-bootstrap-{mock_uuid.return_value}.log",
-                    ),
-                ],
-                shell=False,
-                close_fds=True,
-                start_new_session=True,
-                stdin=subprocess.DEVNULL,
-                stdout=open_mock.return_value,
-                stderr=open_mock.return_value,
-            )
-
-
-class TestLoadConnectionSettings:
-    """
-    Tests for the _load_connection_settings method
-    """
-
-    @patch.object(DataclassMapper, "map")
-    def test_loads_settings(
-        self,
-        mock_map: MagicMock,
-    ):
-        # GIVEN
-        filepath = "/path"
-        connection_settings = {"port": 123}
-
-        # WHEN
-        with patch.object(
-            frontend_runner, "open", mock_open(read_data=json.dumps(connection_settings))
-        ):
-            _load_connection_settings(filepath)
-
-        # THEN
-        mock_map.assert_called_once_with(connection_settings)
-
-    @patch.object(frontend_runner, "open")
-    def test_raises_when_file_open_fails(
-        self,
-        open_mock: MagicMock,
-        caplog: pytest.LogCaptureFixture,
-    ):
-        # GIVEN
-        filepath = "/path"
-        err = OSError()
-        open_mock.side_effect = err
-
-        # WHEN
-        with pytest.raises(OSError) as raised_err:
-            _load_connection_settings(filepath)
-
-        # THEN
-        assert raised_err.value is err
-        assert "Failed to open connection file: " in caplog.text
-
-    @patch.object(frontend_runner.json, "load")
-    def test_raises_when_json_decode_fails(
-        self,
-        mock_json_load: MagicMock,
-        caplog: pytest.LogCaptureFixture,
-    ):
-        # GIVEN
-        filepath = "/path"
-        err = json.JSONDecodeError("", "", 0)
-        mock_json_load.side_effect = err
-
-        # WHEN
-        with pytest.raises(json.JSONDecodeError) as raised_err:
-            with patch.object(frontend_runner, "open", mock_open()):
-                _load_connection_settings(filepath)
-
-        # THEN
-        assert raised_err.value is err
-        assert "Failed to decode connection file: " in caplog.text
 
 
 class TestWaitForFile:
@@ -1105,22 +975,3 @@ class TestWaitForFile:
         assert mock_time.call_count == 2
         mock_exists.assert_called_once_with(filepath)
         mock_sleep.assert_not_called()
-
-
-@patch.object(frontend_runner, "_load_connection_settings")
-def test_connection_settings_lazy_loads(mock_load_connection_settings: MagicMock):
-    # GIVEN
-    filepath = "/path"
-    expected = ConnectionSettings("/socket")
-    mock_load_connection_settings.return_value = expected
-    runner = FrontendRunner(connection_file_path=filepath)
-
-    # Assert the internal connection settings var is not set yet
-    assert not hasattr(runner, "_connection_settings")
-
-    # WHEN
-    actual = runner.connection_settings
-
-    # THEN
-    assert actual is expected
-    assert runner._connection_settings is expected

--- a/test/openjd/adaptor_runtime/unit/background/test_frontend_runner.py
+++ b/test/openjd/adaptor_runtime/unit/background/test_frontend_runner.py
@@ -93,7 +93,7 @@ class TestFrontendRunner:
             conn_file_path = "/path"
             init_data = {"init": "data"}
             path_mapping_data: dict = {}
-            runner = FrontendRunner(conn_file_path)
+            runner = FrontendRunner(connection_file_path=conn_file_path)
 
             # WHEN
             runner.init(adaptor_module, init_data, path_mapping_data, reentry_exe)
@@ -113,24 +113,24 @@ class TestFrontendRunner:
                     adaptor_module.__package__,
                     "daemon",
                     "_serve",
-                    "--connection-file",
-                    conn_file_path,
                     "--init-data",
                     json.dumps(init_data),
                     "--path-mapping-rules",
                     json.dumps(path_mapping_data),
+                    "--connection-file",
+                    conn_file_path,
                 ]
             else:
                 expected_args = [
                     str(reentry_exe),
                     "daemon",
                     "_serve",
-                    "--connection-file",
-                    conn_file_path,
                     "--init-data",
                     json.dumps(init_data),
                     "--path-mapping-rules",
                     json.dumps(path_mapping_data),
+                    "--connection-file",
+                    conn_file_path,
                 ]
             mock_Popen.assert_called_once_with(
                 expected_args,
@@ -148,7 +148,7 @@ class TestFrontendRunner:
             # GIVEN
             adaptor_module = ModuleType("")
             adaptor_module.__package__ = None
-            runner = FrontendRunner("")
+            runner = FrontendRunner(connection_file_path="/tmp/connection.json")
 
             # WHEN
             with pytest.raises(Exception) as raised_exc:
@@ -167,7 +167,7 @@ class TestFrontendRunner:
             adaptor_module = ModuleType("")
             adaptor_module.__package__ = "package"
             conn_file_path = "/path"
-            runner = FrontendRunner(conn_file_path)
+            runner = FrontendRunner(connection_file_path=conn_file_path)
 
             # WHEN
             with pytest.raises(FileExistsError) as raised_err:
@@ -196,7 +196,7 @@ class TestFrontendRunner:
             adaptor_module = ModuleType("")
             adaptor_module.__package__ = "package"
             conn_file_path = "/path"
-            runner = FrontendRunner(conn_file_path)
+            runner = FrontendRunner(connection_file_path=conn_file_path)
 
             # WHEN
             with pytest.raises(Exception) as raised_exc:
@@ -231,7 +231,7 @@ class TestFrontendRunner:
             adaptor_module = ModuleType("")
             adaptor_module.__package__ = "package"
             conn_file_path = "/path"
-            runner = FrontendRunner(conn_file_path)
+            runner = FrontendRunner(connection_file_path=conn_file_path)
 
             # WHEN
             with pytest.raises(TimeoutError) as raised_err:
@@ -267,7 +267,7 @@ class TestFrontendRunner:
             if OSName.is_windows():
                 mock_send_request.return_value = {"body": '{"key1": "value1"}'}
             mock_response = mock_send_request.return_value
-            runner = FrontendRunner("")
+            runner = FrontendRunner(connection_file_path="/tmp/connection.json")
 
             # WHEN
             response = runner._heartbeat()
@@ -295,7 +295,7 @@ class TestFrontendRunner:
             if OSName.is_windows():
                 mock_send_request.return_value = {"body": '{"key1": "value1"}'}
             mock_response = mock_send_request.return_value
-            runner = FrontendRunner("")
+            runner = FrontendRunner(connection_file_path="/tmp/connection.json")
 
             # WHEN
             response = runner._heartbeat(ack_id)
@@ -338,7 +338,9 @@ class TestFrontendRunner:
             mock_event.wait = MagicMock()
             mock_event.is_set = MagicMock(return_value=False)
             heartbeat_interval = 1
-            runner = FrontendRunner("", heartbeat_interval=heartbeat_interval)
+            runner = FrontendRunner(
+                connection_file_path="/tmp/connection.json", heartbeat_interval=heartbeat_interval
+            )
 
             # WHEN
             runner._heartbeat_until_state_complete(state)
@@ -367,7 +369,7 @@ class TestFrontendRunner:
                     failed=False,
                 ),
             ]
-            runner = FrontendRunner("")
+            runner = FrontendRunner(connection_file_path="/tmp/connection.json")
 
             # WHEN
             with pytest.raises(AdaptorFailedException) as raised_exc:
@@ -385,7 +387,7 @@ class TestFrontendRunner:
         @patch.object(FrontendRunner, "_send_request")
         def test_sends_shutdown(self, mock_send_request: MagicMock):
             # GIVEN
-            runner = FrontendRunner("")
+            runner = FrontendRunner(connection_file_path="/tmp/connection.json")
 
             # WHEN
             runner.shutdown()
@@ -407,7 +409,7 @@ class TestFrontendRunner:
         ):
             # GIVEN
             run_data = {"run": "data"}
-            runner = FrontendRunner("")
+            runner = FrontendRunner(connection_file_path="/tmp/connection.json")
 
             # WHEN
             runner.run(run_data)
@@ -429,7 +431,7 @@ class TestFrontendRunner:
             mock_heartbeat_until_state_complete: MagicMock,
         ):
             # GIVEN
-            runner = FrontendRunner("")
+            runner = FrontendRunner(connection_file_path="/tmp/connection.json")
 
             # WHEN
             runner.start()
@@ -451,7 +453,7 @@ class TestFrontendRunner:
             mock_heartbeat_until_state_complete: MagicMock,
         ):
             # GIVEN
-            runner = FrontendRunner("")
+            runner = FrontendRunner(connection_file_path="/tmp/connection.json")
 
             # WHEN
             runner.stop()
@@ -471,7 +473,7 @@ class TestFrontendRunner:
             mock_send_request: MagicMock,
         ):
             # GIVEN
-            runner = FrontendRunner("")
+            runner = FrontendRunner(connection_file_path="/tmp/connection.json")
 
             # WHEN
             runner.cancel()
@@ -502,7 +504,7 @@ class TestFrontendRunner:
             method = "GET"
             path = "/path"
             conn_file_path = "/conn/file/path"
-            runner = FrontendRunner(conn_file_path)
+            runner = FrontendRunner(connection_file_path=conn_file_path)
 
             # WHEN
             response = runner._send_request(method, path)
@@ -529,7 +531,7 @@ class TestFrontendRunner:
             method = "GET"
             path = "/path"
             conn_file_path = "/conn/file/path"
-            runner = FrontendRunner(conn_file_path)
+            runner = FrontendRunner(connection_file_path=conn_file_path)
 
             # WHEN
             with pytest.raises(http_client.HTTPException) as raised_exc:
@@ -559,7 +561,7 @@ class TestFrontendRunner:
             method = "GET"
             path = "/path"
             conn_file_path = "/conn/file/path"
-            runner = FrontendRunner(conn_file_path)
+            runner = FrontendRunner(connection_file_path=conn_file_path)
 
             # WHEN
             with pytest.raises(HTTPError) as raised_err:
@@ -585,7 +587,7 @@ class TestFrontendRunner:
             path = "/path"
             conn_file_path = "/conn/file/path"
             params = {"first param": 1, "second_param": ["one", "two three"]}
-            runner = FrontendRunner(conn_file_path)
+            runner = FrontendRunner(connection_file_path=conn_file_path)
 
             # WHEN
             response = runner._send_request(method, path, params=params)
@@ -606,7 +608,7 @@ class TestFrontendRunner:
             path = "/path"
             conn_file_path = "/conn/file/path"
             json = {"the": "body"}
-            runner = FrontendRunner(conn_file_path)
+            runner = FrontendRunner(connection_file_path=conn_file_path)
 
             # WHEN
             response = runner._send_request(method, path, json_body=json)
@@ -648,7 +650,7 @@ class TestFrontendRunner:
             path = "/path"
             conn_file_path = r"C:\conn\file\path"
 
-            runner = FrontendRunner(conn_file_path)
+            runner = FrontendRunner(connection_file_path=conn_file_path)
 
             # WHEN
             with patch.object(
@@ -680,7 +682,7 @@ class TestFrontendRunner:
             method = "GET"
             path = "/path"
             conn_file_path = r"C:\conn\file\path"
-            runner = FrontendRunner(conn_file_path)
+            runner = FrontendRunner(connection_file_path=conn_file_path)
 
             # WHEN
             with patch.object(
@@ -709,7 +711,7 @@ class TestFrontendRunner:
             method = "GET"
             path = "/path"
             conn_file_path = r"C:\conn\file\path"
-            runner = FrontendRunner(conn_file_path)
+            runner = FrontendRunner(connection_file_path=conn_file_path)
 
             # WHEN
             with patch.object(
@@ -747,7 +749,7 @@ class TestFrontendRunner:
             path = "/path"
             conn_file_path = r"C:\conn\file\path"
             params = {"first param": 1, "second_param": ["one", "two three"]}
-            runner = FrontendRunner(conn_file_path)
+            runner = FrontendRunner(connection_file_path=conn_file_path)
 
             # WHEN
             with patch.object(
@@ -777,7 +779,7 @@ class TestFrontendRunner:
             path = "/path"
             conn_file_path = r"C:\conn\file\path"
             json_body = {"the": "body"}
-            runner = FrontendRunner(conn_file_path)
+            runner = FrontendRunner(connection_file_path=conn_file_path)
 
             # WHEN
             with patch.object(
@@ -805,7 +807,7 @@ class TestFrontendRunner:
 
             # GIVEN
             conn_file_path = "/path/to/conn_file"
-            runner = FrontendRunner(conn_file_path)
+            runner = FrontendRunner(connection_file_path=conn_file_path)
 
             # WHEN
             runner._sigint_handler(MagicMock(), MagicMock())
@@ -949,7 +951,7 @@ def test_connection_settings_lazy_loads(mock_load_connection_settings: MagicMock
     filepath = "/path"
     expected = ConnectionSettings("/socket")
     mock_load_connection_settings.return_value = expected
-    runner = FrontendRunner(filepath)
+    runner = FrontendRunner(connection_file_path=filepath)
 
     # Assert the internal connection settings var is not set yet
     assert not hasattr(runner, "_connection_settings")

--- a/test/openjd/adaptor_runtime/unit/background/test_frontend_runner.py
+++ b/test/openjd/adaptor_runtime/unit/background/test_frontend_runner.py
@@ -196,7 +196,7 @@ class TestFrontendRunner:
                 ]
             expected_args.extend(
                 [
-                    "--log-file",
+                    "--bootstrap-log-file",
                     os.path.join(
                         tempfile.gettempdir(),
                         f"adaptor-runtime-background-bootstrap-{mock_uuid.return_value}.log",

--- a/test/openjd/adaptor_runtime/unit/background/test_loaders.py
+++ b/test/openjd/adaptor_runtime/unit/background/test_loaders.py
@@ -65,6 +65,7 @@ class TestConnectionSettingsFileLoader:
         self,
         open_mock: MagicMock,
         loader: ConnectionSettingsFileLoader,
+        connection_file_path: pathlib.Path,
         caplog: pytest.LogCaptureFixture,
     ):
         # GIVEN
@@ -76,11 +77,12 @@ class TestConnectionSettingsFileLoader:
             loader.load()
 
         # THEN
-        assert "Failed to open connection file: " in caplog.text
+        assert f"Failed to open connection file '{connection_file_path}': " in caplog.text
 
     def test_raises_when_json_decode_fails(
         self,
         loader: ConnectionSettingsFileLoader,
+        connection_file_path: pathlib.Path,
         caplog: pytest.LogCaptureFixture,
     ):
         # GIVEN
@@ -92,7 +94,7 @@ class TestConnectionSettingsFileLoader:
                 loader.load()
 
         # THEN
-        assert "Failed to decode connection file: " in caplog.text
+        assert f"Failed to decode connection file '{connection_file_path}': " in caplog.text
 
 
 class TestConnectionSettingsEnvLoader:

--- a/test/openjd/adaptor_runtime/unit/background/test_loaders.py
+++ b/test/openjd/adaptor_runtime/unit/background/test_loaders.py
@@ -141,6 +141,6 @@ class TestConnectionSettingsEnvLoader:
 
         # THEN
         assert re.match(
-            "Required attribute '.*' does not have its corresponding environment variable '.*' set",
+            "^Required attribute '.*' does not have its corresponding environment variable '.*' set",
             str(raised_err.value),
         )

--- a/test/openjd/adaptor_runtime/unit/background/test_loaders.py
+++ b/test/openjd/adaptor_runtime/unit/background/test_loaders.py
@@ -1,0 +1,146 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+from __future__ import annotations
+
+import dataclasses
+import pathlib
+import json
+import re
+import typing
+from unittest.mock import MagicMock, mock_open, patch
+
+import pytest
+
+from openjd.adaptor_runtime._background import loaders
+from openjd.adaptor_runtime._background.loaders import (
+    ConnectionSettingsEnvLoader,
+    ConnectionSettingsFileLoader,
+    ConnectionSettingsLoadingError,
+)
+from openjd.adaptor_runtime._background.model import (
+    ConnectionSettings,
+)
+
+
+class TestConnectionSettingsFileLoader:
+    """
+    Tests for the ConnectionsettingsFileLoader class
+    """
+
+    @pytest.fixture
+    def connection_settings(self) -> ConnectionSettings:
+        return ConnectionSettings(socket="socket")
+
+    @pytest.fixture(autouse=True)
+    def open_mock(
+        self, connection_settings: ConnectionSettings
+    ) -> typing.Generator[MagicMock, None, None]:
+        with patch.object(
+            loaders,
+            "open",
+            mock_open(read_data=json.dumps(dataclasses.asdict(connection_settings))),
+        ) as m:
+            yield m
+
+    @pytest.fixture
+    def connection_file_path(self) -> pathlib.Path:
+        return pathlib.Path("test")
+
+    @pytest.fixture
+    def loader(self, connection_file_path: pathlib.Path) -> ConnectionSettingsFileLoader:
+        return ConnectionSettingsFileLoader(connection_file_path)
+
+    def test_loads_settings(
+        self,
+        connection_settings: ConnectionSettings,
+        loader: ConnectionSettingsFileLoader,
+    ):
+        # WHEN
+        result = loader.load()
+
+        # THEN
+        assert result == connection_settings
+
+    def test_raises_when_file_open_fails(
+        self,
+        open_mock: MagicMock,
+        loader: ConnectionSettingsFileLoader,
+        caplog: pytest.LogCaptureFixture,
+    ):
+        # GIVEN
+        err = OSError()
+        open_mock.side_effect = err
+
+        # WHEN
+        with pytest.raises(ConnectionSettingsLoadingError):
+            loader.load()
+
+        # THEN
+        assert "Failed to open connection file: " in caplog.text
+
+    def test_raises_when_json_decode_fails(
+        self,
+        loader: ConnectionSettingsFileLoader,
+        caplog: pytest.LogCaptureFixture,
+    ):
+        # GIVEN
+        err = json.JSONDecodeError("", "", 0)
+
+        with patch.object(loaders.json, "load", side_effect=err):
+            with pytest.raises(ConnectionSettingsLoadingError):
+                # WHEN
+                loader.load()
+
+        # THEN
+        assert "Failed to decode connection file: " in caplog.text
+
+
+class TestConnectionSettingsEnvLoader:
+    @pytest.fixture
+    def connection_settings(self) -> ConnectionSettings:
+        return ConnectionSettings(socket="socket")
+
+    @pytest.fixture
+    def mock_env(self, connection_settings: ConnectionSettings) -> dict[str, typing.Any]:
+        return {
+            env_name: getattr(connection_settings, attr_name)
+            for attr_name, (env_name, _) in ConnectionSettingsEnvLoader().env_map.items()
+        }
+
+    @pytest.fixture(autouse=True)
+    def mock_os_environ(
+        self, mock_env: dict[str, typing.Any]
+    ) -> typing.Generator[dict, None, None]:
+        with patch.dict(loaders.os.environ, mock_env) as d:
+            yield d
+
+    @pytest.fixture
+    def loader(self) -> ConnectionSettingsEnvLoader:
+        return ConnectionSettingsEnvLoader()
+
+    def test_loads_connection_settings(
+        self,
+        loader: ConnectionSettingsEnvLoader,
+        connection_settings: ConnectionSettings,
+    ) -> None:
+        # WHEN
+        settings = loader.load()
+
+        # THEN
+        assert connection_settings == settings
+
+    def test_raises_error_when_required_not_provided(
+        self,
+        loader: ConnectionSettingsEnvLoader,
+    ) -> None:
+        # GIVEN
+        with patch.object(loaders.os.environ, "get", return_value=None):
+            with pytest.raises(loaders.ConnectionSettingsLoadingError) as raised_err:
+                # WHEN
+                loader.load()
+
+        # THEN
+        assert re.match(
+            "Required attribute '.*' does not have its corresponding environment variable '.*' set",
+            str(raised_err.value),
+        )

--- a/test/openjd/adaptor_runtime/unit/http/test_sockets.py
+++ b/test/openjd/adaptor_runtime/unit/http/test_sockets.py
@@ -251,9 +251,8 @@ class TestLinuxSocketPaths:
         argvalues=[
             ["a"],
             ["a" * 107],
-            ["/this/part/should/not/matter/" + "a" * 107],
         ],
-        ids=["one byte", "107 bytes", "path with name of 107 bytes"],
+        ids=["one byte", "107 bytes"],
     )
     def test_accepts_names_within_107_bytes(self, path: str):
         """
@@ -295,9 +294,8 @@ class TestMacOSSocketPaths:
         argvalues=[
             ["a"],
             ["a" * 103],
-            ["/this/part/should/not/matter/" + "a" * 103],
         ],
-        ids=["one byte", "103 bytes", "path with name of 103 bytes"],
+        ids=["one byte", "103 bytes"],
     )
     def test_accepts_paths_within_103_bytes(self, path: str):
         """

--- a/test/openjd/adaptor_runtime/unit/http/test_sockets.py
+++ b/test/openjd/adaptor_runtime/unit/http/test_sockets.py
@@ -157,6 +157,17 @@ class TestSocketPaths:
             else:
                 mock_makedirs.assert_not_called()
 
+        def test_uses_base_dir(self) -> None:
+            # GIVEN
+            subject = SocketPathsStub()
+            base_dir = os.path.join(os.sep, "base", "dir")
+
+            # WHEN
+            result = subject.get_socket_path("sock", base_dir=base_dir)
+
+            # THEN
+            assert result.startswith(base_dir)
+
         def test_uses_namespace(self) -> None:
             # GIVEN
             namespace = "my-namespace"
@@ -240,10 +251,11 @@ class TestLinuxSocketPaths:
         argvalues=[
             ["a"],
             ["a" * 107],
+            ["/this/part/should/not/matter/" + "a" * 107],
         ],
-        ids=["one byte", "107 bytes"],
+        ids=["one byte", "107 bytes", "path with name of 107 bytes"],
     )
-    def test_accepts_paths_within_107_bytes(self, path: str):
+    def test_accepts_names_within_107_bytes(self, path: str):
         """
         Verifies the function accepts paths up to 100 bytes (108 byte max - 1 byte null terminator)
         """
@@ -259,7 +271,7 @@ class TestLinuxSocketPaths:
             # THEN
             pass  # success
 
-    def test_rejects_paths_over_107_bytes(self):
+    def test_rejects_names_over_107_bytes(self):
         # GIVEN
         length = 108
         path = "a" * length
@@ -283,8 +295,9 @@ class TestMacOSSocketPaths:
         argvalues=[
             ["a"],
             ["a" * 103],
+            ["/this/part/should/not/matter/" + "a" * 103],
         ],
-        ids=["one byte", "103 bytes"],
+        ids=["one byte", "103 bytes", "path with name of 103 bytes"],
     )
     def test_accepts_paths_within_103_bytes(self, path: str):
         """

--- a/test/openjd/adaptor_runtime/unit/http/test_sockets.py
+++ b/test/openjd/adaptor_runtime/unit/http/test_sockets.py
@@ -220,20 +220,16 @@ class TestSocketPaths:
                 )
             )
 
-        @patch.object(sockets.uuid, "uuid4")
         @patch.object(sockets.os.path, "exists")
         def test_handles_socket_name_collisions(
             self,
             mock_exists: MagicMock,
-            mock_uuid4: MagicMock,
         ) -> None:
             # GIVEN
             sock_name = "sock"
-            existing_sock_names = [sock_name, f"{sock_name}_abc123", f"{sock_name}_123abc"]
+            existing_sock_names = [sock_name, f"{sock_name}_1", f"{sock_name}_2"]
             mock_exists.side_effect = ([True] * len(existing_sock_names)) + [False]
-
-            expected_sock_name = f"{sock_name}_123456789abcdefg"
-            mock_uuid4.side_effect = existing_sock_names[1:] + [expected_sock_name]
+            expected_sock_name = f"{sock_name}_3"
 
             subject = SocketPathsStub()
 

--- a/test/openjd/adaptor_runtime/unit/test_entrypoint.py
+++ b/test/openjd/adaptor_runtime/unit/test_entrypoint.py
@@ -214,7 +214,14 @@ class TestStart:
         # GIVEN
         init_data = {"init": "data"}
         with patch.object(
-            runtime_entrypoint.sys, "argv", ["Adaptor", "run", "--init-data", json.dumps(init_data)]
+            runtime_entrypoint.sys,
+            "argv",
+            [
+                "Adaptor",
+                "run",
+                "--init-data",
+                json.dumps(init_data),
+            ],
         ):
             entrypoint = EntryPoint(mock_adaptor_cls)
 
@@ -487,7 +494,8 @@ class TestStart:
         )
         mock_init.assert_called_once_with(
             mock_adaptor_runner.return_value,
-            conn_file,
+            connection_file_path=conn_file,
+            working_dir=None,
             log_buffer=mock_log_buffer.return_value,
         )
         mock_run.assert_called_once()
@@ -555,7 +563,7 @@ class TestStart:
 
         # THEN
         assert raised_err.match(f"Adaptor module is not loaded: {FakeAdaptor.__module__}")
-        mock_magic_init.assert_called_once_with(conn_file)
+        mock_magic_init.assert_called_once_with(connection_file_path=conn_file, working_dir=None)
 
     @pytest.mark.parametrize(
         argnames="reentry_exe",
@@ -598,7 +606,7 @@ class TestStart:
 
         # THEN
         mock_magic_init.assert_called_once_with(mock_adaptor_module, {}, {}, reentry_exe)
-        mock_magic_start.assert_called_once_with(conn_file)
+        mock_magic_start.assert_called_once_with(connection_file_path=conn_file, working_dir=None)
         mock_start.assert_called_once_with()
 
     @patch.object(FrontendRunner, "__init__", return_value=None)
@@ -629,7 +637,7 @@ class TestStart:
             entrypoint.start()
 
         # THEN
-        mock_magic_init.assert_called_once_with(conn_file)
+        mock_magic_init.assert_called_once_with(connection_file_path=conn_file, working_dir=None)
         mock_end.assert_called_once()
         mock_shutdown.assert_called_once_with()
 
@@ -662,7 +670,7 @@ class TestStart:
             entrypoint.start()
 
         # THEN
-        mock_magic_init.assert_called_once_with(conn_file)
+        mock_magic_init.assert_called_once_with(connection_file_path=conn_file, working_dir=None)
         mock_run.assert_called_once_with(run_data)
 
     @patch.object(FrontendRunner, "__init__", return_value=None)
@@ -729,7 +737,9 @@ class TestStart:
         # THEN
         mock_isabs.assert_any_call(conn_file)
         mock_abspath.assert_any_call(conn_file)
-        mock_runner.assert_called_once_with(mock_abspath.return_value)
+        mock_runner.assert_called_once_with(
+            connection_file_path=mock_abspath.return_value, working_dir=None
+        )
 
 
 class TestLoadData:

--- a/test/openjd/adaptor_runtime/unit/test_entrypoint.py
+++ b/test/openjd/adaptor_runtime/unit/test_entrypoint.py
@@ -496,7 +496,7 @@ class TestStart:
         )
         mock_init.assert_called_once_with(
             mock_adaptor_runner.return_value,
-            connection_file_path=conn_file,
+            connection_file_path=conn_file.resolve(),
             log_buffer=mock_log_buffer.return_value,
         )
         mock_run.assert_called_once()
@@ -609,7 +609,7 @@ class TestStart:
         mock_magic_init.assert_called_once_with()
         mock_init.assert_called_once_with(
             adaptor_module=mock_adaptor_module,
-            connection_file_path=conn_file,
+            connection_file_path=conn_file.resolve(),
             init_data={},
             path_mapping_data={},
             reentry_exe=reentry_exe,

--- a/test/openjd/adaptor_runtime/unit/test_entrypoint.py
+++ b/test/openjd/adaptor_runtime/unit/test_entrypoint.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import signal
 from pathlib import Path
 from typing import Optional
@@ -468,7 +469,7 @@ class TestStart:
     ):
         # GIVEN
         init_data = {"init": "data"}
-        conn_file = "/path/to/conn_file"
+        conn_file = os.path.join(os.sep, "path", "to", "conn_file")
         with patch.object(
             runtime_entrypoint.sys,
             "argv",
@@ -514,7 +515,7 @@ class TestStart:
     ):
         # GIVEN
         init_data = {"init": "data"}
-        conn_file = "/path/to/conn_file"
+        conn_file = os.path.join(os.sep, "path", "to", "conn_file")
         with patch.object(
             runtime_entrypoint.sys,
             "argv",
@@ -542,7 +543,7 @@ class TestStart:
         mock_magic_init: MagicMock,
     ):
         # GIVEN
-        conn_file = "/path/to/conn_file"
+        conn_file = os.path.join(os.sep, "path", "to", "conn_file")
         with patch.object(
             runtime_entrypoint.sys,
             "argv",
@@ -583,7 +584,7 @@ class TestStart:
         reentry_exe: Optional[Path],
     ):
         # GIVEN
-        conn_file = "/path/to/conn_file"
+        conn_file = os.path.join(os.sep, "path", "to", "conn_file")
         with patch.object(
             runtime_entrypoint.sys,
             "argv",
@@ -619,7 +620,7 @@ class TestStart:
         mock_magic_init: MagicMock,
     ):
         # GIVEN
-        conn_file = "/path/to/conn_file"
+        conn_file = os.path.join(os.sep, "path", "to", "conn_file")
         with patch.object(
             runtime_entrypoint.sys,
             "argv",
@@ -649,7 +650,7 @@ class TestStart:
         mock_magic_init: MagicMock,
     ):
         # GIVEN
-        conn_file = "/path/to/conn_file"
+        conn_file = os.path.join(os.sep, "path", "to", "conn_file")
         run_data = {"run": "data"}
         with patch.object(
             runtime_entrypoint.sys,
@@ -683,7 +684,7 @@ class TestStart:
         mock_magic_init: MagicMock,
     ):
         # GIVEN
-        conn_file = "/path/to/conn_file"
+        conn_file = os.path.join(os.sep, "path", "to", "conn_file")
         run_data = {"run": "data"}
         with patch.object(
             runtime_entrypoint.sys,

--- a/test/openjd/adaptor_runtime/unit/test_entrypoint.py
+++ b/test/openjd/adaptor_runtime/unit/test_entrypoint.py
@@ -22,6 +22,7 @@ from openjd.adaptor_runtime.adaptors.configuration import (
 )
 from openjd.adaptor_runtime.adaptors import BaseAdaptor, SemanticVersion
 from openjd.adaptor_runtime._background import BackendRunner, FrontendRunner
+from openjd.adaptor_runtime._background.model import ConnectionSettings
 from openjd.adaptor_runtime._osname import OSName
 from openjd.adaptor_runtime._entrypoint import _load_data
 
@@ -469,7 +470,7 @@ class TestStart:
     ):
         # GIVEN
         init_data = {"init": "data"}
-        conn_file = os.path.join(os.sep, "path", "to", "conn_file")
+        conn_file = Path(os.sep) / "path" / "to" / "conn_file"
         with patch.object(
             runtime_entrypoint.sys,
             "argv",
@@ -480,7 +481,7 @@ class TestStart:
                 "--init-data",
                 json.dumps(init_data),
                 "--connection-file",
-                conn_file,
+                str(conn_file),
             ],
         ):
             entrypoint = EntryPoint(mock_adaptor_cls)
@@ -496,7 +497,6 @@ class TestStart:
         mock_init.assert_called_once_with(
             mock_adaptor_runner.return_value,
             connection_file_path=conn_file,
-            working_dir=None,
             log_buffer=mock_log_buffer.return_value,
         )
         mock_run.assert_called_once()
@@ -543,7 +543,7 @@ class TestStart:
         mock_magic_init: MagicMock,
     ):
         # GIVEN
-        conn_file = os.path.join(os.sep, "path", "to", "conn_file")
+        conn_file = Path(os.sep) / "path" / "to" / "conn_file"
         with patch.object(
             runtime_entrypoint.sys,
             "argv",
@@ -552,7 +552,7 @@ class TestStart:
                 "daemon",
                 "start",
                 "--connection-file",
-                conn_file,
+                str(conn_file),
             ],
         ):
             entrypoint = EntryPoint(FakeAdaptor)
@@ -564,7 +564,7 @@ class TestStart:
 
         # THEN
         assert raised_err.match(f"Adaptor module is not loaded: {FakeAdaptor.__module__}")
-        mock_magic_init.assert_called_once_with(connection_file_path=conn_file, working_dir=None)
+        mock_magic_init.assert_called_once_with()
 
     @pytest.mark.parametrize(
         argnames="reentry_exe",
@@ -579,12 +579,12 @@ class TestStart:
     def test_runs_background_start(
         self,
         mock_start: MagicMock,
+        mock_init: MagicMock,
         mock_magic_init: MagicMock,
-        mock_magic_start: MagicMock,
         reentry_exe: Optional[Path],
     ):
         # GIVEN
-        conn_file = os.path.join(os.sep, "path", "to", "conn_file")
+        conn_file = Path(os.sep) / "path" / "to" / "conn_file"
         with patch.object(
             runtime_entrypoint.sys,
             "argv",
@@ -593,7 +593,7 @@ class TestStart:
                 "daemon",
                 "start",
                 "--connection-file",
-                conn_file,
+                str(conn_file),
             ],
         ):
             mock_adaptor_module = Mock()
@@ -606,10 +606,17 @@ class TestStart:
                 entrypoint.start(reentry_exe=reentry_exe)
 
         # THEN
-        mock_magic_init.assert_called_once_with(mock_adaptor_module, {}, {}, reentry_exe)
-        mock_magic_start.assert_called_once_with(connection_file_path=conn_file, working_dir=None)
+        mock_magic_init.assert_called_once_with()
+        mock_init.assert_called_once_with(
+            adaptor_module=mock_adaptor_module,
+            connection_file_path=conn_file,
+            init_data={},
+            path_mapping_data={},
+            reentry_exe=reentry_exe,
+        )
         mock_start.assert_called_once_with()
 
+    @patch.object(runtime_entrypoint.ConnectionSettingsFileLoader, "load")
     @patch.object(FrontendRunner, "__init__", return_value=None)
     @patch.object(FrontendRunner, "shutdown")
     @patch.object(FrontendRunner, "stop")
@@ -618,9 +625,11 @@ class TestStart:
         mock_end: MagicMock,
         mock_shutdown: MagicMock,
         mock_magic_init: MagicMock,
+        mock_connection_settings_load: MagicMock,
     ):
         # GIVEN
-        conn_file = os.path.join(os.sep, "path", "to", "conn_file")
+        connection_settings = ConnectionSettings("socket")
+        mock_connection_settings_load.return_value = connection_settings
         with patch.object(
             runtime_entrypoint.sys,
             "argv",
@@ -629,7 +638,7 @@ class TestStart:
                 "daemon",
                 "stop",
                 "--connection-file",
-                conn_file,
+                "/path/to/conn/file",
             ],
         ):
             entrypoint = EntryPoint(FakeAdaptor)
@@ -638,19 +647,22 @@ class TestStart:
             entrypoint.start()
 
         # THEN
-        mock_magic_init.assert_called_once_with(connection_file_path=conn_file, working_dir=None)
+        mock_magic_init.assert_called_once_with(connection_settings=connection_settings)
         mock_end.assert_called_once()
         mock_shutdown.assert_called_once_with()
 
+    @patch.object(runtime_entrypoint.ConnectionSettingsFileLoader, "load")
     @patch.object(FrontendRunner, "__init__", return_value=None)
     @patch.object(FrontendRunner, "run")
     def test_runs_background_run(
         self,
         mock_run: MagicMock,
         mock_magic_init: MagicMock,
+        mock_connection_settings_load: MagicMock,
     ):
         # GIVEN
-        conn_file = os.path.join(os.sep, "path", "to", "conn_file")
+        conn_settings = ConnectionSettings("socket")
+        mock_connection_settings_load.return_value = conn_settings
         run_data = {"run": "data"}
         with patch.object(
             runtime_entrypoint.sys,
@@ -662,7 +674,7 @@ class TestStart:
                 "--run-data",
                 json.dumps(run_data),
                 "--connection-file",
-                conn_file,
+                "/path/to/conn/file",
             ],
         ):
             entrypoint = EntryPoint(FakeAdaptor)
@@ -671,9 +683,11 @@ class TestStart:
             entrypoint.start()
 
         # THEN
-        mock_magic_init.assert_called_once_with(connection_file_path=conn_file, working_dir=None)
+        mock_magic_init.assert_called_once_with(connection_settings=conn_settings)
         mock_run.assert_called_once_with(run_data)
+        mock_connection_settings_load.assert_called_once()
 
+    @patch.object(runtime_entrypoint.ConnectionSettingsFileLoader, "load")
     @patch.object(FrontendRunner, "__init__", return_value=None)
     @patch.object(FrontendRunner, "run")
     @patch.object(runtime_entrypoint.signal, "signal")
@@ -682,9 +696,10 @@ class TestStart:
         signal_mock: MagicMock,
         mock_run: MagicMock,
         mock_magic_init: MagicMock,
+        mock_connection_settings_load: MagicMock,
     ):
         # GIVEN
-        conn_file = os.path.join(os.sep, "path", "to", "conn_file")
+        conn_file = Path(os.sep) / "path" / "to" / "conn_file"
         run_data = {"run": "data"}
         with patch.object(
             runtime_entrypoint.sys,
@@ -696,7 +711,7 @@ class TestStart:
                 "--run-data",
                 json.dumps(run_data),
                 "--connection-file",
-                conn_file,
+                str(conn_file),
             ],
         ):
             entrypoint = EntryPoint(FakeAdaptor)
@@ -707,13 +722,15 @@ class TestStart:
         # THEN
         signal_mock.assert_not_called()
 
+    @patch.object(runtime_entrypoint, "ConnectionSettingsFileLoader")
     @patch.object(runtime_entrypoint, "FrontendRunner")
     def test_makes_connection_file_path_absolute(
         self,
         mock_runner: MagicMock,
+        mock_connection_settings_loader: MagicMock,
     ):
         # GIVEN
-        conn_file = "relpath"
+        conn_file = Path("relpath")
         with patch.object(
             runtime_entrypoint.sys,
             "argv",
@@ -722,72 +739,30 @@ class TestStart:
                 "daemon",
                 "run",
                 "--connection-file",
-                conn_file,
+                str(conn_file),
             ],
         ):
             entrypoint = EntryPoint(FakeAdaptor)
 
             # WHEN
-            mock_isabs: MagicMock
+            mock_is_absolute: MagicMock
             with (
-                patch.object(runtime_entrypoint.os.path, "isabs", return_value=False) as mock_isabs,
-                patch.object(runtime_entrypoint.os.path, "abspath") as mock_abspath,
+                patch.object(
+                    runtime_entrypoint.Path, "is_absolute", return_value=False
+                ) as mock_is_absolute,
+                patch.object(
+                    runtime_entrypoint.Path, "absolute", return_value=Path("absolute")
+                ) as mock_absolute,
             ):
                 entrypoint.start()
 
         # THEN
-        mock_isabs.assert_any_call(conn_file)
-        mock_abspath.assert_any_call(conn_file)
+        mock_is_absolute.assert_called_once()
+        mock_absolute.assert_any_call()
+        mock_connection_settings_loader.assert_called_once_with(mock_absolute.return_value)
         mock_runner.assert_called_once_with(
-            connection_file_path=mock_abspath.return_value, working_dir=None
+            connection_settings=mock_connection_settings_loader.return_value.load.return_value
         )
-
-    class TestConnectionFileCompat:
-        @pytest.mark.parametrize(
-            argnames=["connection_file", "working_dir"],
-            argvalues=[
-                ["path", "dir"],
-                [None, None],
-            ],
-            ids=["both provided", "neither provided"],
-        )
-        def test_rejects_not_exactly_one_of_connection_file_and_working_dir(
-            self,
-            connection_file: str | None,
-            working_dir: str | None,
-        ) -> None:
-            # GIVEN
-            entrypoint = EntryPoint(FakeAdaptor)
-            args = [
-                "Adaptor",
-                "daemon",
-                "run",
-            ]
-            if connection_file:
-                args.extend(
-                    [
-                        "--connection-file",
-                        connection_file,
-                    ]
-                )
-            if working_dir:
-                args.extend(
-                    [
-                        "--working-dir",
-                        working_dir,
-                    ]
-                )
-
-            with patch.object(runtime_entrypoint.sys, "argv", args):
-                with pytest.raises(RuntimeError) as raised_err:
-                    # WHEN
-                    entrypoint.start()
-
-            # THEN
-            assert (
-                "Expected exactly one of 'connection_file' or 'working_dir' to be provided, but got args: "
-                in str(raised_err.value)
-            )
 
 
 class TestLoadData:

--- a/test/openjd/adaptor_runtime/unit/test_entrypoint.py
+++ b/test/openjd/adaptor_runtime/unit/test_entrypoint.py
@@ -742,6 +742,53 @@ class TestStart:
             connection_file_path=mock_abspath.return_value, working_dir=None
         )
 
+    class TestConnectionFileCompat:
+        @pytest.mark.parametrize(
+            argnames=["connection_file", "working_dir"],
+            argvalues=[
+                ["path", "dir"],
+                [None, None],
+            ],
+            ids=["both provided", "neither provided"],
+        )
+        def test_rejects_not_exactly_one_of_connection_file_and_working_dir(
+            self,
+            connection_file: str | None,
+            working_dir: str | None,
+        ) -> None:
+            # GIVEN
+            entrypoint = EntryPoint(FakeAdaptor)
+            args = [
+                "Adaptor",
+                "daemon",
+                "run",
+            ]
+            if connection_file:
+                args.extend(
+                    [
+                        "--connection-file",
+                        connection_file,
+                    ]
+                )
+            if working_dir:
+                args.extend(
+                    [
+                        "--working-dir",
+                        working_dir,
+                    ]
+                )
+
+            with patch.object(runtime_entrypoint.sys, "argv", args):
+                with pytest.raises(RuntimeError) as raised_err:
+                    # WHEN
+                    entrypoint.start()
+
+            # THEN
+            assert (
+                "Expected exactly one of 'connection_file' or 'working_dir' to be provided, but got args: "
+                in str(raised_err.value)
+            )
+
 
 class TestLoadData:
     """

--- a/test/openjd/adaptor_runtime_client/integ/test_integration_client_interface.py
+++ b/test/openjd/adaptor_runtime_client/integ/test_integration_client_interface.py
@@ -53,7 +53,7 @@ class TestIntegrationClientInterface:
         # Ensure the process actually shutdown
         assert client_subprocess.returncode is not None
 
-    def test_client_in_thread_does_not_do_graceful_shutdown(self):
+    def test_client_in_thread_does_not_do_graceful_shutdown(self) -> None:
         """Ensures that a client running in a thread does not crash by attempting to register a signal,
         since they can only be created in the main thread. This means the graceful shutdown is effectively
         ignored."""


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
- The unix socket names created by the adaptor runtime can collide once PIDs are reused by the OS. Normally, these files are cleaned up, but if the runtime crashes, they can be left around and cause collision issues.

### What was the solution? (How)
- Have the socket creation code check if the socket already exists. If it does, keep checking if `<pid>_<counter>` exists until it is available and use that.
- Sockets are now created in the system temp directory.
- Added daemon bootstrap logging (via a new `--log-file` option only exposed in the `_serve` command) so that if the daemon bootstrap fails, we are able to look at the logs and determine what went wrong. Daemon bootstrap logging stops logging to the file after bootstrap is complete.
- Improved the `--connection-file` CLI help text
- Removed the `worker` path component from configuration file paths
- Add support for configuring connection data via environment variables. Currently, there is only one env var needed, `OPENJD_ADAPTOR_SOCKET`.
    - The `<adaptor> daemon start` command has been updated to emit an `openjd_env: OPENJD_ADAPTOR_SOCKET=<path-to-socket>` line to stdout so that, when running in an OpenJD environment, the option is automatically set and subsequent commands within this OpenJD environment no longer need to pass in a `--connection-file` argument.
- The `--connection-file` argument is no longer necessary if `OPENJD_ADAPTOR_SOCKET` is provided
    - The `<adaptor> daemon start` command will still generate a connection file at a temporary directory when it is not provided, then delete it after daemon bootstrap is complete.
- Small cleanup/fixes:
    - Rename classes/methods `sockets.py` module to refer to "paths" rather than "directories"
    - Fix unit/integ tests expecting unix style paths
    - Moved OpenJD constants into a `_utils._constants.py` file

### What is the impact of this change?
- Adaptor runtime handles socket name collisions now
- OpenJD job templates that run `<adaptor> daemon start` in an OpenJD environment no longer need to pass `--connection-file` anymore

### How was this change tested?
- Added/updated unit tests
- Added integration test
- Manual testing, see below

### Was this change documented?
No

### Is this a breaking change?
No, the modified interface is internal to this package, under the `_http` package

## Manual testing

### Test adaptor files

**__main__.py**
```
import openjd.adaptor_runtime as runtime
from .adaptor import FakeAdaptor

if __name__ == "__main__":
    try:
        runtime.EntryPoint(FakeAdaptor).start()
    except Exception as e:
        print(f"Unexpected error in adaptor main: {e}")
        raise
    else:
        print("nice")
```

**adaptor.py**
```
import openjd.adaptor_runtime.adaptors as adaptors
class FakeAdaptor(adaptors.BaseAdaptor):
    def __init__(self, init_data: dict, **kwargs):
        super().__init__(init_data, **kwargs)
    @property
    def integration_data_interface_version(self) -> adaptors.SemanticVersion:
        return adaptors.SemanticVersion(major=0, minor=1)
    def _start(self):
        pass
    def _run(self, run_data: dict):
        pass
    def _cleanup(self):
        pass
    def _stop(self):
        pass
```

### Test logs - Linux with Env Var

```
(fake-adaptor) $ fake-adaptor daemon start
INFO: Applying user-level configuration: /home/jericht/.openjd/adaptors/runtime/configuration.json
INFO: Applying user-level configuration: /home/jericht/.openjd/adaptors/FakeAdaptor/FakeAdaptor.json
INFO: Initializing backend process...
INFO: Started backend process. PID: 5089
INFO: Waiting for File '/tmp/ojd-ar-_n9r_2og/connection.json' to exist
INFO: Retrying in 1s...
INFO: Waiting for File '/tmp/ojd-ar-_n9r_2og/connection.json' to be openable
INFO: Waiting for File '/tmp/ojd-ar-_n9r_2og/connection.json' to have valid ConnectionSettings
INFO: ========== BEGIN BOOTSTRAP OUTPUT CONTENTS ==========
INFO: INFO: Applying user-level configuration: /home/jericht/.openjd/adaptors/runtime/configuration.json
INFO: INFO: Applying user-level configuration: /home/jericht/.openjd/adaptors/FakeAdaptor/FakeAdaptor.json
INFO: ========== END BOOTSTRAP OUTPUT CONTENTS ==========
INFO: Checking for bootstrap logs at '/tmp/adaptor-runtime-background-bootstrap-191fb704-90c3-4e06-a399-8fc7c12c231e.log'
INFO: ========== BEGIN BOOTSTRAP LOG CONTENTS ==========
INFO: [2024-05-28 21:49:36,443][INFO    ] Applying user-level configuration: /home/jericht/.openjd/adaptors/runtime/configuration.json
INFO: [2024-05-28 21:49:36,445][INFO    ] Applying user-level configuration: /home/jericht/.openjd/adaptors/FakeAdaptor/FakeAdaptor.json
INFO: [2024-05-28 21:49:36,445][INFO    ] Running in background daemon mode.
INFO: ========== END BOOTSTRAP LOG CONTENTS ==========
INFO: Verifying connection to backend...
INFO: Connected successfully
openjd_env: OPENJD_ADAPTOR_SOCKET=/tmp/.openjd_adaptor_runtime/5089
ADAPTOR_OUTPUT: INFO: Running in background daemon mode.
nice
(fake-adaptor) $ export OPENJD_ADAPTOR_SOCKET=/tmp/.openjd_adaptor_runtime/5089
(fake-adaptor) $ fake-adaptor daemon run
INFO: Applying user-level configuration: /home/jericht/.openjd/adaptors/runtime/configuration.json
INFO: Applying user-level configuration: /home/jericht/.openjd/adaptors/FakeAdaptor/FakeAdaptor.json
ADAPTOR_OUTPUT: 
nice
(fake-adaptor) $ fake-adaptor daemon stop
INFO: Applying user-level configuration: /home/jericht/.openjd/adaptors/runtime/configuration.json
INFO: Applying user-level configuration: /home/jericht/.openjd/adaptors/FakeAdaptor/FakeAdaptor.json
ADAPTOR_OUTPUT: 
ADAPTOR_OUTPUT: INFO: Daemon background process stopped.
nice
```

### Test Logs - Linux with connection file

```
(fake-adaptor) $ fake-adaptor daemon start --connection-file /tmp/connection.json
INFO: Applying user-level configuration: /home/jericht/.openjd/adaptors/runtime/configuration.json
INFO: Applying user-level configuration: /home/jericht/.openjd/adaptors/FakeAdaptor/FakeAdaptor.json
INFO: Initializing backend process...
INFO: Started backend process. PID: 5556
INFO: Waiting for File '/tmp/connection.json' to exist
INFO: Retrying in 1s...
INFO: Waiting for File '/tmp/connection.json' to be openable
INFO: Waiting for File '/tmp/connection.json' to have valid ConnectionSettings
INFO: ========== BEGIN BOOTSTRAP OUTPUT CONTENTS ==========
INFO: INFO: Applying user-level configuration: /home/jericht/.openjd/adaptors/runtime/configuration.json
INFO: INFO: Applying user-level configuration: /home/jericht/.openjd/adaptors/FakeAdaptor/FakeAdaptor.json
INFO: ========== END BOOTSTRAP OUTPUT CONTENTS ==========
INFO: Checking for bootstrap logs at '/tmp/adaptor-runtime-background-bootstrap-edca8ed7-1ca7-41ef-844b-904aa6b9afa6.log'
INFO: ========== BEGIN BOOTSTRAP LOG CONTENTS ==========
INFO: [2024-05-28 21:50:09,943][INFO    ] Applying user-level configuration: /home/jericht/.openjd/adaptors/runtime/configuration.json
INFO: [2024-05-28 21:50:09,945][INFO    ] Applying user-level configuration: /home/jericht/.openjd/adaptors/FakeAdaptor/FakeAdaptor.json
INFO: [2024-05-28 21:50:09,945][INFO    ] Running in background daemon mode.
INFO: ========== END BOOTSTRAP LOG CONTENTS ==========
INFO: Verifying connection to backend...
INFO: Connected successfully
openjd_env: OPENJD_ADAPTOR_SOCKET=/tmp/.openjd_adaptor_runtime/5556
ADAPTOR_OUTPUT: INFO: Running in background daemon mode.
nice
(fake-adaptor) $ cat /tmp/connection.json 
{"socket": "/tmp/.openjd_adaptor_runtime/5556"}(fake-adaptor) $ 
(fake-adaptor) $ fake-adaptor daemon run --connection-file /tmp/connection.json
INFO: Applying user-level configuration: /home/jericht/.openjd/adaptors/runtime/configuration.json
INFO: Applying user-level configuration: /home/jericht/.openjd/adaptors/FakeAdaptor/FakeAdaptor.json
ADAPTOR_OUTPUT: 
nice
(fake-adaptor) $ fake-adaptor daemon stop --connection-file /tmp/connection.json
INFO: Applying user-level configuration: /home/jericht/.openjd/adaptors/runtime/configuration.json
INFO: Applying user-level configuration: /home/jericht/.openjd/adaptors/FakeAdaptor/FakeAdaptor.json
ADAPTOR_OUTPUT: 
ADAPTOR_OUTPUT: INFO: Daemon background process stopped.
nice
```

### Test Logs - Mac with env var

```
(fake-adaptor) jericht fake-adaptor % fake-adaptor daemon start
INFO: Creating empty configuration at /Users/jericht/.openjd/adaptors/runtime/configuration.json
INFO: Applying user-level configuration: /Users/jericht/.openjd/adaptors/runtime/configuration.json
INFO: Creating empty configuration at /Users/jericht/.openjd/adaptors/FakeAdaptor/FakeAdaptor.json
INFO: Applying user-level configuration: /Users/jericht/.openjd/adaptors/FakeAdaptor/FakeAdaptor.json
INFO: Initializing backend process...
INFO: Started backend process. PID: 41645
INFO: Waiting for File '/var/folders/1z/3kw8_st57n9c_wsjd5n898wh0000gq/T/ojd-ar-__td_97m/connection.json' to exist
INFO: Retrying in 1s...
INFO: Waiting for File '/var/folders/1z/3kw8_st57n9c_wsjd5n898wh0000gq/T/ojd-ar-__td_97m/connection.json' to be openable
INFO: Waiting for File '/var/folders/1z/3kw8_st57n9c_wsjd5n898wh0000gq/T/ojd-ar-__td_97m/connection.json' to have valid ConnectionSettings
INFO: ========== BEGIN BOOTSTRAP OUTPUT CONTENTS ==========
INFO: INFO: Applying user-level configuration: /Users/jericht/.openjd/adaptors/runtime/configuration.json
INFO: INFO: Applying user-level configuration: /Users/jericht/.openjd/adaptors/FakeAdaptor/FakeAdaptor.json
INFO: ========== END BOOTSTRAP OUTPUT CONTENTS ==========
INFO: Checking for bootstrap logs at '/var/folders/1z/3kw8_st57n9c_wsjd5n898wh0000gq/T/adaptor-runtime-background-bootstrap-7333d334-3f39-4b27-8f59-a1465611f1bc.log'
INFO: ========== BEGIN BOOTSTRAP LOG CONTENTS ==========
INFO: [2024-05-28 14:44:45,339][INFO    ] Applying user-level configuration: /Users/jericht/.openjd/adaptors/runtime/configuration.json
INFO: [2024-05-28 14:44:45,340][INFO    ] Applying user-level configuration: /Users/jericht/.openjd/adaptors/FakeAdaptor/FakeAdaptor.json
INFO: [2024-05-28 14:44:45,341][INFO    ] Running in background daemon mode.
INFO: ========== END BOOTSTRAP LOG CONTENTS ==========
INFO: Verifying connection to backend...
INFO: Connected successfully
openjd_env: OPENJD_ADAPTOR_SOCKET=/private/var/folders/1z/3kw8_st57n9c_wsjd5n898wh0000gq/T/.openjd_adaptor_runtime/41645
ADAPTOR_OUTPUT: INFO: Running in background daemon mode.
nice
(fake-adaptor) jericht fake-adaptor % export OPENJD_ADAPTOR_SOCKET=/private/var/folders/1z/3kw8_st57n9c_wsjd5n898wh0000gq/T/.openjd_adaptor_runtime/41645 
(fake-adaptor) jericht fake-adaptor % fake-adaptor daemon run
INFO: Applying user-level configuration: /Users/jericht/.openjd/adaptors/runtime/configuration.json
INFO: Applying user-level configuration: /Users/jericht/.openjd/adaptors/FakeAdaptor/FakeAdaptor.json
ADAPTOR_OUTPUT: 
nice
(fake-adaptor) jericht fake-adaptor % fake-adaptor daemon stop
INFO: Applying user-level configuration: /Users/jericht/.openjd/adaptors/runtime/configuration.json
INFO: Applying user-level configuration: /Users/jericht/.openjd/adaptors/FakeAdaptor/FakeAdaptor.json
ADAPTOR_OUTPUT: 
ADAPTOR_OUTPUT: INFO: Daemon background process stopped.
nice

```

### Test Logs - Mac with connection file

```
(fake-adaptor) jericht fake-adaptor % fake-adaptor daemon start --connection-file /tmp/connection.json
INFO: Applying user-level configuration: /Users/jericht/.openjd/adaptors/runtime/configuration.json
INFO: Applying user-level configuration: /Users/jericht/.openjd/adaptors/FakeAdaptor/FakeAdaptor.json
INFO: Initializing backend process...
INFO: Started backend process. PID: 41858
INFO: Waiting for File '/tmp/connection.json' to exist
INFO: Retrying in 1s...
INFO: Waiting for File '/tmp/connection.json' to be openable
INFO: Waiting for File '/tmp/connection.json' to have valid ConnectionSettings
INFO: ========== BEGIN BOOTSTRAP OUTPUT CONTENTS ==========
INFO: INFO: Applying user-level configuration: /Users/jericht/.openjd/adaptors/runtime/configuration.json
INFO: INFO: Applying user-level configuration: /Users/jericht/.openjd/adaptors/FakeAdaptor/FakeAdaptor.json
INFO: ========== END BOOTSTRAP OUTPUT CONTENTS ==========
INFO: Checking for bootstrap logs at '/var/folders/1z/3kw8_st57n9c_wsjd5n898wh0000gq/T/adaptor-runtime-background-bootstrap-954cf37a-0839-423c-aa70-90e46d6aefb6.log'
INFO: ========== BEGIN BOOTSTRAP LOG CONTENTS ==========
INFO: [2024-05-28 14:46:36,493][INFO    ] Applying user-level configuration: /Users/jericht/.openjd/adaptors/runtime/configuration.json
INFO: [2024-05-28 14:46:36,494][INFO    ] Applying user-level configuration: /Users/jericht/.openjd/adaptors/FakeAdaptor/FakeAdaptor.json
INFO: [2024-05-28 14:46:36,494][INFO    ] Running in background daemon mode.
INFO: ========== END BOOTSTRAP LOG CONTENTS ==========
INFO: Verifying connection to backend...
INFO: Connected successfully
openjd_env: OPENJD_ADAPTOR_SOCKET=/private/var/folders/1z/3kw8_st57n9c_wsjd5n898wh0000gq/T/.openjd_adaptor_runtime/41858
ADAPTOR_OUTPUT: INFO: Running in background daemon mode.
nice
(fake-adaptor) jericht fake-adaptor % cat /tmp/connection.json 
{"socket": "/private/var/folders/1z/3kw8_st57n9c_wsjd5n898wh0000gq/T/.openjd_adaptor_runtime/41858"}%                                          (fake-adaptor) jericht fake-adaptor % fake-adaptor daemon run --connection-file /tmp/connection.json
INFO: Applying user-level configuration: /Users/jericht/.openjd/adaptors/runtime/configuration.json
INFO: Applying user-level configuration: /Users/jericht/.openjd/adaptors/FakeAdaptor/FakeAdaptor.json
ADAPTOR_OUTPUT: 
nice
(fake-adaptor) jericht fake-adaptor % fake-adaptor daemon stop --connection-file /tmp/connection.json
INFO: Applying user-level configuration: /Users/jericht/.openjd/adaptors/runtime/configuration.json
INFO: Applying user-level configuration: /Users/jericht/.openjd/adaptors/FakeAdaptor/FakeAdaptor.json
ADAPTOR_OUTPUT: 
ADAPTOR_OUTPUT: INFO: Daemon background process stopped.
nice
```

### Test Logs - Windows with env var

```
(fake-adaptor) C:\Users\Administrator\Desktop\fake-adaptor>fake-adaptor daemon start
INFO: Applying user-level configuration: C:\Users\Administrator\.openjd\adaptors\runtime\configuration.json
INFO: Applying user-level configuration: C:\Users\Administrator\.openjd\adaptors\FakeAdaptor\FakeAdaptor.json
INFO: Initializing backend process...
INFO: Started backend process. PID: 2336
INFO: Waiting for File 'C:\Users\ADMINI~1\AppData\Local\Temp\2\ojd-ar-72f64zef\connection.json' to exist
INFO: Retrying in 1s...
INFO: Waiting for File 'C:\Users\ADMINI~1\AppData\Local\Temp\2\ojd-ar-72f64zef\connection.json' to be openable
INFO: Waiting for File 'C:\Users\ADMINI~1\AppData\Local\Temp\2\ojd-ar-72f64zef\connection.json' to have valid ConnectionSettings
INFO: ========== BEGIN BOOTSTRAP OUTPUT CONTENTS ==========
INFO: INFO: Applying user-level configuration: C:\Users\Administrator\.openjd\adaptors\runtime\configuration.json
INFO: INFO: Applying user-level configuration: C:\Users\Administrator\.openjd\adaptors\FakeAdaptor\FakeAdaptor.json
INFO: ========== END BOOTSTRAP OUTPUT CONTENTS ==========
INFO: Checking for bootstrap logs at 'C:\Users\ADMINI~1\AppData\Local\Temp\2\adaptor-runtime-background-bootstrap-2fd74b9e-188a-456e-a4ed-10dc470b9623.log'
INFO: ========== BEGIN BOOTSTRAP LOG CONTENTS ==========
INFO: [2024-05-28 21:57:12,622][INFO    ] Applying user-level configuration: C:\Users\Administrator\.openjd\adaptors\runtime\configuration.json
INFO: [2024-05-28 21:57:12,622][INFO    ] Applying user-level configuration: C:\Users\Administrator\.openjd\adaptors\FakeAdaptor\FakeAdaptor.json
INFO: [2024-05-28 21:57:12,622][INFO    ] Running in background daemon mode.
INFO: [2024-05-28 21:57:12,622][INFO    ] Creating Named Pipe with name: \\.\pipe\AdaptorNamedPipe_5612
INFO: ========== END BOOTSTRAP LOG CONTENTS ==========
INFO: Verifying connection to backend...
INFO: Connected successfully
openjd_env: OPENJD_ADAPTOR_SOCKET=\\.\pipe\AdaptorNamedPipe_5612
ADAPTOR_OUTPUT: INFO: Running in background daemon mode.
ADAPTOR_OUTPUT: INFO: Creating Named Pipe with name: \\.\pipe\AdaptorNamedPipe_5612
nice

(fake-adaptor) C:\Users\Administrator\Desktop\fake-adaptor>set "OPENJD_ADAPTOR_SOCKET=\\.\pipe\AdaptorNamedPipe_5612"

(fake-adaptor) C:\Users\Administrator\Desktop\fake-adaptor>fake-adaptor daemon run
INFO: Applying user-level configuration: C:\Users\Administrator\.openjd\adaptors\runtime\configuration.json
INFO: Applying user-level configuration: C:\Users\Administrator\.openjd\adaptors\FakeAdaptor\FakeAdaptor.json
ADAPTOR_OUTPUT:
nice

(fake-adaptor) C:\Users\Administrator\Desktop\fake-adaptor>fake-adaptor daemon stop
INFO: Applying user-level configuration: C:\Users\Administrator\.openjd\adaptors\runtime\configuration.json
INFO: Applying user-level configuration: C:\Users\Administrator\.openjd\adaptors\FakeAdaptor\FakeAdaptor.json
ADAPTOR_OUTPUT:
ADAPTOR_OUTPUT: INFO: Daemon background process stopped.
nice
```

### Test Logs - Windows with connection file

```
(fake-adaptor) C:\Users\Administrator\Desktop\fake-adaptor>fake-adaptor daemon start --connection-file connection.json
INFO: Applying user-level configuration: C:\Users\Administrator\.openjd\adaptors\runtime\configuration.json
INFO: Applying user-level configuration: C:\Users\Administrator\.openjd\adaptors\FakeAdaptor\FakeAdaptor.json
INFO: Initializing backend process...
INFO: Started backend process. PID: 2092
INFO: Waiting for File 'C:\Users\Administrator\Desktop\fake-adaptor\connection.json' to exist
INFO: Retrying in 1s...
INFO: Waiting for File 'C:\Users\Administrator\Desktop\fake-adaptor\connection.json' to be openable
INFO: Waiting for File 'C:\Users\Administrator\Desktop\fake-adaptor\connection.json' to have valid ConnectionSettings
INFO: ========== BEGIN BOOTSTRAP OUTPUT CONTENTS ==========
INFO: INFO: Applying user-level configuration: C:\Users\Administrator\.openjd\adaptors\runtime\configuration.json
INFO: INFO: Applying user-level configuration: C:\Users\Administrator\.openjd\adaptors\FakeAdaptor\FakeAdaptor.json
INFO: ========== END BOOTSTRAP OUTPUT CONTENTS ==========
INFO: Checking for bootstrap logs at 'C:\Users\ADMINI~1\AppData\Local\Temp\2\adaptor-runtime-background-bootstrap-cc17769b-250e-43ce-8296-c43bc7b8486b.log'
INFO: ========== BEGIN BOOTSTRAP LOG CONTENTS ==========
INFO: [2024-05-28 21:56:15,434][INFO    ] Applying user-level configuration: C:\Users\Administrator\.openjd\adaptors\runtime\configuration.json
INFO: [2024-05-28 21:56:15,434][INFO    ] Applying user-level configuration: C:\Users\Administrator\.openjd\adaptors\FakeAdaptor\FakeAdaptor.json
INFO: [2024-05-28 21:56:15,434][INFO    ] Running in background daemon mode.
INFO: [2024-05-28 21:56:15,434][INFO    ] Creating Named Pipe with name: \\.\pipe\AdaptorNamedPipe_2084
INFO: ========== END BOOTSTRAP LOG CONTENTS ==========
INFO: Verifying connection to backend...
INFO: Connected successfully
openjd_env: OPENJD_ADAPTOR_SOCKET=\\.\pipe\AdaptorNamedPipe_2084
ADAPTOR_OUTPUT: INFO: Running in background daemon mode.
ADAPTOR_OUTPUT: INFO: Creating Named Pipe with name: \\.\pipe\AdaptorNamedPipe_2084
nice

(fake-adaptor) C:\Users\Administrator\Desktop\fake-adaptor>type connection.json
{"socket": "\\\\.\\pipe\\AdaptorNamedPipe_2084"}
(fake-adaptor) C:\Users\Administrator\Desktop\fake-adaptor>fake-adaptor daemon run --connection-file connection.json
INFO: Applying user-level configuration: C:\Users\Administrator\.openjd\adaptors\runtime\configuration.json
INFO: Applying user-level configuration: C:\Users\Administrator\.openjd\adaptors\FakeAdaptor\FakeAdaptor.json
ADAPTOR_OUTPUT:
nice

(fake-adaptor) C:\Users\Administrator\Desktop\fake-adaptor>fake-adaptor daemon stop --connection-file connection.json
INFO: Applying user-level configuration: C:\Users\Administrator\.openjd\adaptors\runtime\configuration.json
INFO: Applying user-level configuration: C:\Users\Administrator\.openjd\adaptors\FakeAdaptor\FakeAdaptor.json
ADAPTOR_OUTPUT:
ADAPTOR_OUTPUT: INFO: Daemon background process stopped.
nice
```

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*