### PR TITLE
chore: sanitize self.path before logging

### DIFF
--- a/src/openjd/adaptor_runtime/_http/request_handler.py
+++ b/src/openjd/adaptor_runtime/_http/request_handler.py
@@ -98,7 +98,8 @@ class RequestHandler(server.BaseHTTPRequestHandler):
             self.send_response(response.status)
         else:
             self.send_error(response.status)
-        _logger.debug(f"Sending status code {response.status} for request to {self.path}")
+        path_to_log = self.path.replace("\r\n", "").replace("\n", "")
+        _logger.debug(f"Sending status code {response.status} for request to {path_to_log}")
 
         if response.body:
             body = response.body.encode("utf-8")


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

CodeQL pointed out a log injection finding here: https://github.com/OpenJobDescription/openjd-adaptor-runtime-for-python/security/code-scanning/27

It's technically a log injection point because `self.path` is [automatically set by](https://github.com/python/cpython/blob/3.12/Lib/http/server.py#L335) `http.server` based on the path in the request e.g. `localhost/<this part>`, so if somebody connected to the adaptor runtime server, they can sort of get whatever they want in the server logs by what they make the path in their request. 

For a variety of reasons, this is not an actual threat (server is running locally, socket validation is performed to ensure only the same user can connect, only one process can connect to the socket at once, integrations hard code the paths, etc)

### What was the solution? (How)

In this case I opted for the suggested solution of removing newlines. 

### What is the impact of this change?

CodeQL is happy ;)

### How was this change tested?
Not tested

### Was this change documented?
No

### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*