### PR TITLE
chore(deps): update ruff, mypy

### DIFF
--- a/hatch.toml
+++ b/hatch.toml
@@ -8,7 +8,7 @@ sync = "pip install -r requirements-testing.txt"
 test = "pytest --cov-config pyproject.toml {args:test}"
 typing = "mypy {args:src test}"
 style = [
-  "ruff {args:.}",
+  "ruff check {args:.}",
   "black --check --diff {args:.}",
 ]
 fmt = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,20 +100,22 @@ explicit_package_bases = true
 mypy_path = "src"
 
 [tool.ruff]
+line-length = 100
+
+[tool.ruff.lint]
 ignore = [
   "E501",
   # Double Check if this should be fixed
   "E731",
 ]
-line-length = 100
 
 
-[tool.ruff.pep8-naming]
+[tool.ruff.lint.pep8-naming]
 classmethod-decorators = [
   "classmethod",
 ]
 
-[tool.ruff.isort]
+[tool.ruff.lint.isort]
 known-first-party = [
   "openjd",
 ]

--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -5,7 +5,7 @@ pytest-cov == 5.0.*
 pytest-timeout == 2.3.*
 pytest-xdist == 3.6.*
 black == 24.*
-ruff == 0.4.*
-mypy == 1.10.*
+ruff == 0.6.*
+mypy == 1.11.*
 psutil == 5.9.*
 types-PyYAML ~= 6.0

--- a/src/openjd/adaptor_runtime/_background/model.py
+++ b/src/openjd/adaptor_runtime/_background/model.py
@@ -38,7 +38,7 @@ class HeartbeatResponse:
 
 class DataclassJSONEncoder(json.JSONEncoder):  # pragma: no cover
     def default(self, o: Any) -> Dict:
-        if dataclasses.is_dataclass(o):
+        if dataclasses.is_dataclass(o) and not isinstance(o, type):
             return dataclasses.asdict(o)
         else:
             return super().default(o)


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Updates of some linting deps required manual changes. Decided to group them here

### What was the solution? (How)

Mypy was flagging 

```
if dataclasses.is_dataclass(o):
    return dataclasses.asdict(o)
```

because `.is_dataclass` returns true if `o` is either type `DataclassInstance` or `Type[DataclassInstance]`. but `asdict` doesn't take `Type[DatclassInstance]`. Added another conditional that `o` is not a `type` for this case.

`ruff` has moved some things around and removed `ruff <path>` in favour of `ruff check <path>`

### What is the impact of this change?

Updated linting deps

### How was this change tested?

`hatch run lint && hatch run test`

### Was this change documented?

No, it's just updating testing deps

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*