### PR TITLE
feat: Adding optional override for adaptor request timeout default to EntryPoint start method

### DIFF
--- a/src/openjd/adaptor_runtime/_background/frontend_runner.py
+++ b/src/openjd/adaptor_runtime/_background/frontend_runner.py
@@ -34,6 +34,8 @@ from .model import (
     HeartbeatResponse,
 )
 
+_FRONTEND_RUNNER_REQUEST_TIMEOUT: float = 5.0
+
 if OSName.is_windows():
     from ...adaptor_runtime_client.named_pipe.named_pipe_helper import NamedPipeHelper
     import pywintypes
@@ -57,7 +59,7 @@ class FrontendRunner:
     def __init__(
         self,
         *,
-        timeout_s: float = 5.0,
+        timeout_s: float = _FRONTEND_RUNNER_REQUEST_TIMEOUT,
         heartbeat_interval: float = 1.0,
         connection_settings: ConnectionSettings | None = None,
     ) -> None:

--- a/src/openjd/adaptor_runtime/_entrypoint.py
+++ b/src/openjd/adaptor_runtime/_entrypoint.py
@@ -250,7 +250,7 @@ class EntryPoint:
     def start(
         self,
         reentry_exe: Optional[Path] = None,
-        timeout_in_seconds: Optional[float] = _FRONTEND_RUNNER_REQUEST_TIMEOUT,
+        timeout_in_seconds: float = _FRONTEND_RUNNER_REQUEST_TIMEOUT,
     ) -> None:
         """
         Starts the run of the adaptor.

--- a/src/openjd/adaptor_runtime/_entrypoint.py
+++ b/src/openjd/adaptor_runtime/_entrypoint.py
@@ -257,7 +257,7 @@ class EntryPoint:
 
         Args:
             reentry_exe (Path): The path to the binary executable that for adaptor reentry.
-            timeout_in_seconds (Optional[float]): The maximum time in seconds to wait for data before
+            timeout_in_seconds (float): The maximum time in seconds to wait for data before
                 raising a TimeoutError. Defaults to 5 seconds. None means waiting indefinitely.
         """
         parser, parsed_args = self._parse_args()

--- a/src/openjd/adaptor_runtime/_entrypoint.py
+++ b/src/openjd/adaptor_runtime/_entrypoint.py
@@ -31,6 +31,7 @@ import yaml
 
 from .adaptors import AdaptorRunner, BaseAdaptor
 from ._background import BackendRunner, FrontendRunner, InMemoryLogBuffer, LogBufferHandler
+from ._background.frontend_runner import _FRONTEND_RUNNER_REQUEST_TIMEOUT
 from ._background.loaders import (
     ConnectionSettingsFileLoader,
     ConnectionSettingsEnvLoader,
@@ -246,12 +247,18 @@ class EntryPoint:
             ),
         )
 
-    def start(self, reentry_exe: Optional[Path] = None) -> None:
+    def start(
+        self,
+        reentry_exe: Optional[Path] = None,
+        timeout_in_seconds: Optional[float] = _FRONTEND_RUNNER_REQUEST_TIMEOUT,
+    ) -> None:
         """
         Starts the run of the adaptor.
 
         Args:
             reentry_exe (Path): The path to the binary executable that for adaptor reentry.
+            timeout_in_seconds (Optional[float]): The maximum time in seconds to wait for data before
+                raising a TimeoutError. Defaults to 5 seconds. None means waiting indefinitely.
         """
         parser, parsed_args = self._parse_args()
         log_config = self._init_loggers(
@@ -300,7 +307,7 @@ class EntryPoint:
             return self._handle_run(adaptor, integration_data)
         elif parsed_args.command == "daemon":  # pragma: no branch
             return self._handle_daemon(
-                adaptor, parsed_args, log_config, integration_data, reentry_exe
+                adaptor, parsed_args, log_config, integration_data, timeout_in_seconds, reentry_exe
             )
 
     def _handle_is_compatible(
@@ -367,6 +374,7 @@ class EntryPoint:
         parsed_args: _ParsedArgs,
         log_config: _LogConfig,
         integration_data: _IntegrationData,
+        timeout_in_seconds: float,
         reentry_exe: Optional[Path] = None,
     ):
         # Validate args
@@ -408,7 +416,7 @@ class EntryPoint:
             # This process is running in frontend mode. Create the frontend runner and send
             # the appropriate request to the backend.
             if subcommand == "start":
-                frontend = FrontendRunner()
+                frontend = FrontendRunner(timeout_s=timeout_in_seconds)
                 adaptor_module = sys.modules.get(self.adaptor_class.__module__)
                 if adaptor_module is None:
                     raise ModuleNotFoundError(
@@ -435,7 +443,9 @@ class EntryPoint:
                     else ConnectionSettingsEnvLoader()
                 )
                 conn_settings = conn_settings_loader.load()
-                frontend = FrontendRunner(connection_settings=conn_settings)
+                frontend = FrontendRunner(
+                    connection_settings=conn_settings, timeout_s=timeout_in_seconds
+                )
                 if subcommand == "run":
                     frontend.run(integration_data.run_data)
                 elif subcommand == "stop":


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
In some DCCs such as Unreal the default request timer maximum of 5 seconds is not long enough to handle some extremely resource intensive processes which occur during or shortly after startup such as asset discovery.

### What was the solution? (How)
Provide an optional override which can be set in our DCC integrations adaptors to extend the timer when appropriate.

### What is the impact of this change?
Adaptors won't time out waiting for responses from the openjd back end.

### How was this change tested?
New test added, existing tests pass, manual testing.

- Have you run the unit tests?

Yes
### Was this change documented?
No

- Are relevant docstrings in the code base updated?
Yes

### Is this a breaking change?
No

### Does this change impact security?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*