### PR TITLE
chore: test pywin32 ==307

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
 dependencies = [
   "pyyaml ~= 6.0",
   "jsonschema >= 4.17.0, == 4.*",
-  "pywin32 == 308; platform_system == 'Windows'",
+  "pywin32 ==307; platform_system == 'Windows'",
 ]
 
 [project.urls]


### PR DESCRIPTION
This PR is simply tests that the Windows CI runners pass when pywin32 307 is used. For more information, please see https://github.com/OpenJobDescription/openjd-adaptor-runtime-for-python/pull/162