### PR TITLE
chore: increase log level for daemon _serve args to info

### DIFF
--- a/src/openjd/adaptor_runtime/_background/frontend_runner.py
+++ b/src/openjd/adaptor_runtime/_background/frontend_runner.py
@@ -149,7 +149,7 @@ class FrontendRunner:
         )
         args.extend(["--bootstrap-log-file", bootstrap_log_path])
 
-        _logger.debug(f"Running process with args: {args}")
+        _logger.info(f"Running process with args: {args}")
         bootstrap_output_path = os.path.join(
             bootstrap_log_dir, f"adaptor-runtime-background-bootstrap-output-{bootstrap_id}.log"
         )

--- a/test/openjd/adaptor_runtime/integ/test_integration_entrypoint.py
+++ b/test/openjd/adaptor_runtime/integ/test_integration_entrypoint.py
@@ -112,8 +112,8 @@ class TestCommandAdaptorDaemon:
             assert "Connected successfully" in caplog.text
             assert "Running in background daemon mode." in caplog.text
             assert "Daemon background process stopped." in caplog.text
-            assert "on_prerun" not in caplog.text
-            assert "on_postrun" not in caplog.text
+            assert "on_prerun" in caplog.text
+            assert "on_postrun" in caplog.text
 
         def test_run(self, caplog: pytest.LogCaptureFixture, tmp_path: Path):
             # GIVEN

--- a/test/openjd/adaptor_runtime/unit/background/test_frontend_runner.py
+++ b/test/openjd/adaptor_runtime/unit/background/test_frontend_runner.py
@@ -219,6 +219,34 @@ class TestFrontendRunner:
             )
             mock_heartbeat.assert_called_once()
 
+        def test_arguments_to_daemon_serve_are_logged_at_info_level(
+            self,
+            mock_path_exists: MagicMock,
+            mock_Popen: MagicMock,
+            caplog: pytest.LogCaptureFixture,
+        ):
+            # GIVEN
+            caplog.set_level("INFO")
+            mock_path_exists.return_value = False
+            adaptor_module = ModuleType("")
+            adaptor_module.__package__ = "package"
+            conn_file_path = Path("/path")
+            runner = FrontendRunner()
+
+            # WHEN
+            runner.init(
+                adaptor_module=adaptor_module,
+                connection_file_path=conn_file_path,
+            )
+
+            # THEN
+            assert any(
+                "Running process with args" in captured_message
+                for captured_message in caplog.messages
+            )
+            mock_path_exists.assert_called_once_with()
+            mock_Popen.assert_called_once()
+
         def test_raises_when_adaptor_module_not_package(self):
             # GIVEN
             adaptor_module = ModuleType("")


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
As I was debugging an issue with starting an adaptor, I got the error message
```
2024/12/16 21:45:13-06:00 INFO: Initializing backend process...
2024/12/16 21:45:13-06:00 ERROR: Failed to initialize backend process: [WinError 193] %1 is not a valid Win32 application
2024/12/16 21:45:13-06:00 ERROR: Entrypoint failed: [WinError 193] %1 is not a valid Win32 application
2024/12/16 21:45:13-06:00 Process pid 3584 exited with code: 1 (unsigned) / 0x1 (hex)
```

It's difficult to understand what went wrong here because the error message does not contain the command that was attempted to be run.

### What was the solution? (How)
Increased log level from debug to info when printing out the arrgs that are about to be run before this command.

### What is the impact of this change?
This will make it easier to debug issues when adaptors fail to start.

### How was this change tested?
Added a unit test for the logs being printed at INFO level, it passed.

- Have you run the unit tests?
Yes

### Was this change documented?
No, N/A

### Is this a breaking change?
No

### Does this change impact security?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*