### PR TITLE
fix!: Ensure YAML/JSON loading uses UTF-8 instead of default encoding.

### DIFF
--- a/src/openjd/adaptor_runtime/_entrypoint.py
+++ b/src/openjd/adaptor_runtime/_entrypoint.py
@@ -590,14 +590,14 @@ def _load_data(data: str) -> dict:
 
 def _load_yaml_json(data: str) -> Any:
     """
-    Loads a YAML/JSON file/string.
+    Loads a YAML/JSON file/string using the UTF-8 encoding.
 
     Note that yaml.safe_load() is capable of loading JSON documents.
     """
     loaded_yaml = None
     if data.startswith("file://"):
         filepath = data[len("file://") :]
-        with open(filepath) as yaml_file:
+        with open(filepath, encoding="utf-8") as yaml_file:
             loaded_yaml = yaml.safe_load(yaml_file)
     else:
         loaded_yaml = yaml.safe_load(data)

--- a/test/openjd/adaptor_runtime/unit/test_entrypoint.py
+++ b/test/openjd/adaptor_runtime/unit/test_entrypoint.py
@@ -860,12 +860,14 @@ class TestLoadData:
 
         # WHEN
         open_mock: MagicMock
-        with patch.object(runtime_entrypoint, "open", mock_open(read_data=input)) as open_mock:
+        with patch.object(
+            runtime_entrypoint, "open", mock_open(read_data=input), "encoding=utf8"
+        ) as open_mock:
             output = _load_data(file_uri)
 
         # THEN
         assert output == expected
-        open_mock.assert_called_once_with(filepath)
+        open_mock.assert_called_once_with(filepath, encoding="utf-8")
 
     @patch.object(runtime_entrypoint, "open")
     def test_raises_on_os_error(self, mock_open: MagicMock, caplog: pytest.LogCaptureFixture):
@@ -880,7 +882,7 @@ class TestLoadData:
 
         # THEN
         assert raised_err.value is mock_open.side_effect
-        mock_open.assert_called_once_with(filepath)
+        mock_open.assert_called_once_with(filepath, encoding="utf-8")
         assert "Failed to open data file: " in caplog.text
 
     def test_raises_when_parsing_fails(self, caplog: pytest.LogCaptureFixture):


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Cinema 4D submissions fail to run if filenames contain non-ASCII values. For example, a scene file named `TestSceneñ.c4d ` would not render.

openjd_fail: Error encountered while starting adaptor: 
Cinema4D Encountered an Error: FileNotFoundError: The scene file 'C:\some_path\TestñSceneñ.c4d' does not exist

### What was the solution? (How)

While loading the JSON/YAML files, the default `open()` uses system's encoding standard which is not UTF-8. 
This causes issues in other DCCs when they try to read the data. 

### What is the impact of this change?
This is not a full fix but a partial fix. Even after adding this change we will have few issues with logging that also uses default encoding and not "utf-8". The fix for that issue is currently in progress. 

### How was this change tested?

While renders now work for characters like

- Symbols like for Bitcoin ₿
- Latin character ę
- Greek character β
- Cyrillic Б
- and many more

![Screenshot 2024-12-19 at 3 44 55 PM](https://github.com/user-attachments/assets/30479c6a-5fba-449f-a08f-0442ff2c80f9)


They still fail for emoji and some mathematical operators. [Cinema 4D's load document function returns None](https://github.com/aws-deadline/deadline-cloud-for-cinema-4d/blob/mainline/src/deadline/cinema4d_adaptor/Cinema4DClient/cinema4d_handler.py#L180) without details on why it fails.

Additionally, it also fails for the Latin character ñ while logging which is currently being investigated. 

- Have you run the unit tests?

Yes

### Was this change documented?
Yes. 

### Is this a breaking change?

I discussed this with @AWS-Samuel and considering the packages are public, we have to operate under the assumption that customers are using the packages in their own, potentially private integrations. So even if we handle the change gracefully in all our integrations its still a breaking change. 

#### If so, then please describe the changes that users of this package must make to update their scripts, or Python applications.

Users of this package must update their dependent packages to ensure that they use "UTF-8" encoding as well. 

### Does this change impact security?

- Does the change need to be threat modeled? For example, does it create or modify files/directories that must only be readable by the process owner?
No 
    - If so, then please label this pull request with the "security" label. We'll work with you to analyze the threats.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*