### PR TITLE
chore: changes for mypy update

### DIFF
--- a/hatch.toml
+++ b/hatch.toml
@@ -5,7 +5,7 @@ pre-install-commands = [
 
 [envs.default.scripts]
 sync = "pip install -r requirements-testing.txt"
-test = "pytest --cov-config pyproject.toml {args:test}"
+test = "pytest --cov-config pyproject.toml {args:test} -vv"
 typing = "mypy {args:src test}"
 style = [
   "ruff check {args:.}",

--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -6,6 +6,6 @@ pytest-timeout == 2.3.*
 pytest-xdist == 3.6.*
 black == 25.*
 ruff == 0.11.*
-mypy == 1.11.*
+mypy == 1.15.*
 psutil == 7.0.*
 types-PyYAML ~= 6.0

--- a/src/openjd/adaptor_runtime/_background/model.py
+++ b/src/openjd/adaptor_runtime/_background/model.py
@@ -3,7 +3,8 @@
 import dataclasses as dataclasses
 import json as json
 from enum import Enum as Enum
-from typing import Any, ClassVar, Dict, Generic, Iterable, Type, TypeVar, cast
+from enum import EnumMeta
+from typing import Any, ClassVar, Dict, Type, TypeVar, cast, Generic
 
 from ..adaptors import AdaptorState
 
@@ -100,14 +101,12 @@ class DataclassMapper(Generic[_T]):
 
             value = o[field.name]
             if dataclasses.is_dataclass(field.type):
-                value = DataclassMapper(field.type).map(value)
-            elif issubclass(field.type, Enum):
-                [value] = [
-                    enum
-                    # Need to cast here for mypy
-                    for enum in cast(Iterable[Enum], list(field.type))
-                    if enum.value == value
-                ]
+                # The init function expects a type, so any dataclasses in cls
+                # will be a type.
+                value = DataclassMapper(cast(type, field.type)).map(value)
+            elif isinstance(field.type, EnumMeta):
+                value = field.type(value)
+
             args[field.name] = value
 
         return self._cls(**args)

--- a/src/openjd/adaptor_runtime/adaptors/configuration/_configuration_manager.py
+++ b/src/openjd/adaptor_runtime/adaptors/configuration/_configuration_manager.py
@@ -23,10 +23,11 @@ _DIR = os.path.dirname(os.path.realpath(__file__))
 
 _ConfigType = TypeVar("_ConfigType", bound=Configuration)
 _AdaptorConfigType = TypeVar("_AdaptorConfigType", bound=AdaptorConfiguration)
+_AdaptorConfigClassType = Type[_AdaptorConfigType]
 
 
 def create_adaptor_configuration_manager(
-    config_cls: Type[_AdaptorConfigType],
+    config_cls: _AdaptorConfigClassType,
     adaptor_name: str,
     default_config_path: str,
     schema_path: str | List[str] | None = None,

--- a/src/openjd/adaptor_runtime/process/_logging_subprocess.py
+++ b/src/openjd/adaptor_runtime/process/_logging_subprocess.py
@@ -177,6 +177,7 @@ class LoggingSubprocess(object):
             self._process.kill()
             self._process.wait()
         else:
+            signal_type: signal.Signals
             if OSName.is_windows():  # pragma: is-posix
                 # We use `CREATE_NEW_PROCESS_GROUP` to create the process,
                 # so pid here is also the process group id and SIGBREAK can be only sent to the process group.

--- a/test/openjd/adaptor_runtime/unit/background/test_model.py
+++ b/test/openjd/adaptor_runtime/unit/background/test_model.py
@@ -2,9 +2,20 @@
 
 import dataclasses
 
+from enum import Enum
+
 import pytest
 
 from openjd.adaptor_runtime._background.model import DataclassMapper
+
+
+class StrEnum(str, Enum):
+    TEST = "test_str"
+    TEST_UNI = "test_☃"
+
+
+class NormalEnum(Enum):
+    ONE = 1
 
 
 # Define two dataclasses to use for tests
@@ -17,6 +28,9 @@ class Inner:
 class Outer:
     outer_key: str
     inner: Inner
+    test_str: StrEnum
+    test_str_unicode: StrEnum
+    normal_enum: NormalEnum
 
 
 class TestDataclassMapper:
@@ -26,17 +40,29 @@ class TestDataclassMapper:
 
     def test_maps_nested_dataclass(self):
         # GIVEN
-        input = {"outer_key": "outer_value", "inner": {"key": "value"}}
+        input = {
+            "outer_key": "outer_value",
+            "inner": {
+                "key": "value",
+            },
+            "test_str": "test_str",
+            "test_str_unicode": "test_☃",
+            "normal_enum": 1,
+        }
         mapper = DataclassMapper(Outer)
 
         # WHEN
         result = mapper.map(input)
 
         # THEN
-        assert isinstance(result, Outer)
-        assert isinstance(result.inner, Inner)
-        assert result.outer_key == "outer_value"
-        assert result.inner.key == "value"
+        expected_dataclass = Outer(
+            outer_key="outer_value",
+            inner=Inner(key="value"),
+            test_str=StrEnum.TEST,
+            test_str_unicode=StrEnum.TEST_UNI,
+            normal_enum=NormalEnum.ONE,
+        )
+        assert result == expected_dataclass
 
     def test_raises_when_field_is_missing(self):
         # GIVEN

--- a/test/openjd/adaptor_runtime_client/integ/test_integration_client_interface.py
+++ b/test/openjd/adaptor_runtime_client/integ/test_integration_client_interface.py
@@ -35,6 +35,7 @@ class TestIntegrationClientInterface:
 
         # To avoid a race condition, giving some extra time for the logging subprocess to start.
         _sleep(0.5 if OSName.is_posix() else 4)
+        signal_type: signal.Signals
         if OSName.is_windows():
             signal_type = signal.CTRL_BREAK_EVENT  # type: ignore[attr-defined]
         else:
@@ -77,6 +78,7 @@ class TestIntegrationClientInterface:
 
         # To avoid a race condition, giving some extra time for the logging subprocess to start.
         _sleep(0.5 if OSName.is_posix() else 4)
+        signal_type: signal.Signals
         if OSName.is_windows():
             signal_type = signal.CTRL_BREAK_EVENT  # type: ignore[attr-defined]
         else:


### PR DESCRIPTION
Fixes: https://github.com/OpenJobDescription/openjd-adaptor-runtime-for-python/pull/179

### What was the problem/requirement? (What/Why)
See https://github.com/OpenJobDescription/openjd-adaptor-runtime-for-python/actions/runs/14341779725/job/40202541223?pr=179

A mypy update detected some issues.

### What was the solution? (How)
Be more precise in the code with typing. There were a couple function calls that had mis-matched types.

In `model.py` reassert what we know to be true about the type.

In `_configuration_manager.py` the type in the function argument was actually incorrect. We wanted the class type, not an instance.

I also found a kind of bug in `DataclassMapper`. We were never actually reaching the code that maps an enum value to an enum. Now in practice this didn't matter because we were using string enums and the underlying data we were checking is the same whether or not the value is an enum. However this wasn't the intent of the code, we wanted an accurate mapping to the enum.

The issue was that we were checking if the field was a subclass of `Enum`. The typing stuff gets kinda confusing here, the enum field type is actually `EnumMeta`, which isn't a subclass of `Enum`. 

It's called `EnumType` in Python >= 3.11, we'll use `EnumMeta` for backward compatibility as `EnumMeta` is an alias for `EnumType` in Python >= 3.11

So now we check if the field is an `EnumMeta`. The code afterwords could be simplified quite a bit after we know that it's an `Enum` as well.

### What is the impact of this change?
More accurate typing, hopefully more robust code.

### How was this change tested?

`hatch run test`

I also added tests for mapping `Enums` as these were missing before.

- Have you run the unit tests?
Yep

### Was this change documented?
Nothing to document.

- Are relevant docstrings in the code base updated?
Ya, this doesn't impact any of the public APIs.

### Is this a breaking change?
No

### Does this change impact security?
No
- Does the change need to be threat modeled? For example, does it create or modify files/directories that must only be readable by the process owner?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*