### PR TITLE
chore(deps): update pytest to 8.3.*

### DIFF
--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -1,6 +1,6 @@
 coverage[toml] == 7.*
 coverage-conditional-plugin == 0.9.0
-pytest == 7.4.*
+pytest == 8.3.*
 pytest-cov == 6.1.*
 pytest-timeout == 2.4.*
 pytest-xdist == 3.6.*

--- a/test/openjd/adaptor_runtime/integ/background/test_background_mode.py
+++ b/test/openjd/adaptor_runtime/integ/background/test_background_mode.py
@@ -29,10 +29,15 @@ from openjd.adaptor_runtime._osname import OSName
 
 mod_path = (Path(__file__).parent.parent).resolve()
 sys.path.append(str(mod_path))
+
 if (_pypath := os.environ.get("PYTHONPATH")) is not None:
     os.environ["PYTHONPATH"] = os.pathsep.join((_pypath, str(mod_path)))
 else:
     os.environ["PYTHONPATH"] = str(mod_path)
+
+# Add the module path to PYTHONPATH for subprocesses
+os.environ["PYTEST_XDIST_WORKER_PYTHONPATH"] = str(mod_path)
+
 from AdaptorExample import AdaptorExample  # noqa: E402
 
 

--- a/test/openjd/adaptor_runtime/integ/test_integration_entrypoint.py
+++ b/test/openjd/adaptor_runtime/integ/test_integration_entrypoint.py
@@ -20,10 +20,15 @@ from openjd.adaptor_runtime._osname import OSName
 
 mod_path = Path(__file__).parent.resolve()
 sys.path.append(str(mod_path))
+
 if (_pypath := os.environ.get("PYTHONPATH")) is not None:
-    os.environ["PYTHONPATH"] = ":".join((_pypath, str(mod_path)))
+    os.environ["PYTHONPATH"] = os.pathsep.join([_pypath, str(mod_path)])
 else:
     os.environ["PYTHONPATH"] = str(mod_path)
+
+# Add the module path to PYTHONPATH for subprocesses
+os.environ["PYTEST_XDIST_WORKER_PYTHONPATH"] = str(mod_path)
+
 from CommandAdaptorExample import CommandAdaptorExample  # noqa: E402
 
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

xdist and parallel test workers are not able to import our example modules `AdaptorExample` and `CommandAdaptorExample` on Windows, seems the subprocesses cannot access `PYTHONPATH` in the latest version of pytest.

### What was the solution? (How)

Set `PYTEST_XDIST_WORKER_PYTHONPATH` to allow workers to access the modules

### What is the impact of this change?
Support latest version of pytest

### How was this change tested?

```
hatch run lint
hatch run test

```
### Was this change documented?

N/A

### Is this a breaking change?

No

### Does this change impact security?

No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*