### PR TITLE
fix: sdist failed to install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,11 +66,9 @@ destinations = [
 ]
 
 [tool.hatch.build.targets.sdist]
-packages = [
+include = [
   "src/openjd",
-]
-only-include = [
-  "src/openjd",
+  "hatch_version_hook.py",
 ]
 
 [tool.hatch.build.targets.wheel]


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

When running `pip install` with an sdist (compressed or uncompressed) you get:
```
OSError: Build script does not exist: hatch_version_hook.py
```

### What was the solution? (How)

Instead of packaging only the package for sdist, we also now include the custom script

### What is the impact of this change?

buildable/installable sdist

### How was this change tested?

```
hatch clean && hatch build && pip install --force-reinstall dist/openjd*.tar.gz
```

### Was this change documented?

N/A

### Is this a breaking change?
N/A

### Does this change impact security?

N/A

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*