### PR TITLE
feat: Adds a more user friendly message when the exectuable isn't found

### DIFF
--- a/src/openjd/adaptor_runtime/process/_logging_subprocess.py
+++ b/src/openjd/adaptor_runtime/process/_logging_subprocess.py
@@ -81,7 +81,7 @@ class LoggingSubprocess(object):
             # If we didn't find the executable found by which
             if exe_path is not None:
                 raise FileNotFoundError(
-                    f"Could not find adaptor executable at: {exe_path} using alias {executable}\n"
+                    f"Could not find executable at: {exe_path} using alias {executable}\n"
                     f"Error:{fnf_error}"
                 )
 

--- a/src/openjd/adaptor_runtime/process/_logging_subprocess.py
+++ b/src/openjd/adaptor_runtime/process/_logging_subprocess.py
@@ -86,8 +86,8 @@ class LoggingSubprocess(object):
                 )
 
             raise FileNotFoundError(
-                f"Could not find the executable associated with the adaptor: {executable}\n"
-                f"Is the executable on the PATH or in the startup directory?\n"
+                f"Could not find the specified command: {executable}\n"
+                f"Ensure the command is available from the PATH environment variable.\n"
                 f"Error:{fnf_error}"
             )
 

--- a/src/openjd/adaptor_runtime/process/_logging_subprocess.py
+++ b/src/openjd/adaptor_runtime/process/_logging_subprocess.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import logging
+import shutil
 import signal
 import subprocess
 import uuid
@@ -21,7 +22,11 @@ _logger = logging.getLogger(__name__)
 
 
 class LoggingSubprocess(object):
-    """A process whose stdout/stderr lines are sent to a configurable logger"""
+    """A process whose stdout/stderr lines are sent to a configurable logger
+
+    Raises:
+         FileNotFoundError: When the executable the adaptor is set to run cannot be found.
+    """
 
     _logger: logging.Logger
     _process: subprocess.Popen
@@ -64,7 +69,27 @@ class LoggingSubprocess(object):
             # In Windows, this is required for signal. SIGBREAK will be sent to the entire process group.
             # Without this one, current process will also get the SIGBREAK and may react incorrectly.
             popen_params.update(creationflags=subprocess.CREATE_NEW_PROCESS_GROUP)  # type: ignore[attr-defined]
-        self._process = subprocess.Popen(**popen_params)
+
+        try:
+            self._process = subprocess.Popen(**popen_params)
+
+        except FileNotFoundError as fnf_error:
+            # In ManagedProcess we prepend the executable to the list of arguments before creating a LoggingSubprocess
+            executable = args[0]
+            exe_path = shutil.which(executable)
+
+            # If we didn't find the executable found by which
+            if exe_path is not None:
+                raise FileNotFoundError(
+                    f"Could not find adaptor executable at: {exe_path} using alias {executable}\n"
+                    f"Error:{fnf_error}"
+                )
+
+            raise FileNotFoundError(
+                f"Could not find the executable associated with the adaptor: {executable}\n"
+                f"Is the executable on the PATH or in the startup directory?\n"
+                f"Error:{fnf_error}"
+            )
 
         if not self._process.stdout:  # pragma: no cover
             raise RuntimeError("process stdout not set")

--- a/test/openjd/adaptor_runtime/integ/process/test_integration_logging_subprocess.py
+++ b/test/openjd/adaptor_runtime/integ/process/test_integration_logging_subprocess.py
@@ -113,9 +113,9 @@ class TestIntegrationLoggingSubprocess(object):
     def test_startup_directory_empty_posix(self):
         """When calling LoggingSubprocess with an empty cwd, FileNotFoundError will be raised."""
         args = ["pwd"]
-        with pytest.raises(FileNotFoundError) as excinfo:
+        with pytest.raises(FileNotFoundError) as exc_info:
             LoggingSubprocess(args=args, startup_directory="")
-        assert "[Errno 2] No such file or directory: ''" in str(excinfo.value)
+        assert "[Errno 2] No such file or directory: ''" in str(exc_info.value)
 
     @pytest.mark.skipif(not OSName.is_windows(), reason="Only run this test in Windows.")
     def test_startup_directory_empty_windows(self):
@@ -150,6 +150,13 @@ class TestIntegrationLoggingSubprocess(object):
             assert not any(r.message == message and r.levelno == _STDOUT_LEVEL for r in records)
 
         assert any(r.message == message and r.levelno == _STDERR_LEVEL for r in records)
+
+    def test_executable_not_found(self):
+        """When calling LoggingSubprocess with a missing executable, FileNotFoundError will be raised"""
+        args = ["missing_executable"]
+        with pytest.raises(FileNotFoundError) as exc_info:
+            LoggingSubprocess(args=args)
+        assert "Could not find the executable associated with the adaptor" in str(exc_info.value)
 
 
 class TestIntegrationRegexHandler(object):

--- a/test/openjd/adaptor_runtime/integ/process/test_integration_logging_subprocess.py
+++ b/test/openjd/adaptor_runtime/integ/process/test_integration_logging_subprocess.py
@@ -156,7 +156,7 @@ class TestIntegrationLoggingSubprocess(object):
         args = ["missing_executable"]
         with pytest.raises(FileNotFoundError) as exc_info:
             LoggingSubprocess(args=args)
-        assert "Could not find the executable associated with the adaptor" in str(exc_info.value)
+        assert "Could not find the specified command" in str(exc_info.value)
 
 
 class TestIntegrationRegexHandler(object):


### PR DESCRIPTION
Fixes: [#113 
](https://github.com/OpenJobDescription/openjd-adaptor-runtime-for-python/issues/113)

### What was the problem/requirement? (What/Why)

When the adaptor fails to find the set executable, it'll fail with [WinError 2] The system cannot find the file specified, which without any context doesn't set users up to sort the issue out.

### What was the solution? (How)

This change adds user friendly messages about what's failing and possible reasons why.

### What is the impact of this change?

Users will see more logging when the adaptor fails to find the executable it has been set to run.

### How was this change tested?

Currently a gap in this PR - I'm not sure where to start testing if a file does or does not exist and modifying the environment within a test.

See [DEVELOPMENT.md](https://github.com/OpenJobDescription/openjd-adaptor-runtime-for-python/blob/mainline/DEVELOPMENT.md#testing) for information on running tests.

- Have you run the unit tests?

### Was this change documented?

Yes, to failures on TestIntegrationClientInterface, TestIntegrationLoggingSubprocess, and TestDaemonMode:

FAILED test/openjd/adaptor_runtime_client/integ/test_integration_client_interface.py::TestIntegrationClientInterface::test_graceful_shutdown - AssertionError: assert 'Received SIGTERM signal.' in ''
FAILED test/openjd/adaptor_runtime/integ/process/test_integration_logging_subprocess.py::TestIntegrationLoggingSubprocess::test_stop_process[StopProcessWhenSIGTERMFails] - Failed: Timeout >5.0s
FAILED test/openjd/adaptor_runtime/integ/background/test_background_mode.py::TestDaemonMode::test_shutdown - psutil.TimeoutExpired: timeout after 1 seconds (pid=11312)

I'm working in the Windows subsystem for Linux which might be the cause of the failing timeouts but I'm not sure about the SIGTERM issue. I'm hoping the github runners shed a little light on what's happening.

- Are relevant docstrings in the code base updated?

Yes.

### Is this a breaking change?

No.

### Does this change impact security?

No.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*