### PR TITLE
feat: print adaptor and runtime version on start

### DIFF
--- a/src/openjd/adaptor_runtime/_entrypoint.py
+++ b/src/openjd/adaptor_runtime/_entrypoint.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import contextlib
+import importlib.metadata
 import logging
 import os
 import signal
@@ -46,6 +47,7 @@ from ._utils._logging import (
     ConditionalFormatter,
 )
 from .adaptors import SemanticVersion
+from ._version import version as _RUNTIME_VERSION
 
 if TYPE_CHECKING:  # pragma: no cover
     from .adaptors.configuration import AdaptorConfiguration
@@ -242,6 +244,53 @@ class EntryPoint:
             ).integration_data_interface_version,
         )
 
+    def _get_adaptor_package_version(self) -> str:
+        """
+        Attempts to determine the package version of the adaptor using the runtime.
+
+        Uses importlib.metadata to find the distribution that owns the adaptor's module
+        file. Returns "UNKNOWN" if the version cannot be determined.
+        """
+        adaptor_module_name = self.adaptor_class.__module__
+
+        # Convert module path to a file path to match against distribution records.
+        # e.g. "deadline.max_adaptor.MaxAdaptor.adaptor" -> "deadline/max_adaptor/MaxAdaptor/adaptor.py"
+        module_file_path = adaptor_module_name.replace(".", "/") + ".py"
+
+        # Find distributions that provide the top-level package, then check which one
+        # owns the adaptor's module file. packages_distributions() requires Python 3.11+.
+        _packages_distributions = getattr(importlib.metadata, "packages_distributions", None)
+        if _packages_distributions is not None:
+            top_level_package = adaptor_module_name.split(".")[0]
+            pkg_to_dists = _packages_distributions()
+            candidate_dists = []
+            for name in pkg_to_dists.get(top_level_package, []):
+                try:
+                    candidate_dists.append(importlib.metadata.distribution(name))
+                except importlib.metadata.PackageNotFoundError:
+                    continue
+
+            for dist in candidate_dists:
+                if dist.files:
+                    for f in dist.files:
+                        if str(f) == module_file_path or str(f).endswith("/" + module_file_path):
+                            return dist.version
+
+        # Fallback: walk up module path looking for a _version module in sys.modules
+        parts = adaptor_module_name.split(".")
+        for i in range(len(parts) - 1, 0, -1):
+            candidate_package = ".".join(parts[:i])
+            version_module_name = f"{candidate_package}._version"
+            version_module = sys.modules.get(version_module_name)
+            if version_module and hasattr(version_module, "version"):
+                return version_module.version
+
+        _logger.warning(
+            f"Could not determine package version for adaptor '{self.adaptor_class.__name__}'. "
+            f"Looked up module: '{adaptor_module_name}'"
+        )
+        return "UNKNOWN"
+
     def _get_integration_data(self, parsed_args: Namespace) -> _IntegrationData:
         return _IntegrationData(
             init_data=parsed_args.init_data if hasattr(parsed_args, "init_data") else {},
@@ -272,6 +321,11 @@ class EntryPoint:
                 else None
             )
         )
+
+        # Log package versions at startup
+        _logger.info(f"openjd-adaptor-runtime version: {_RUNTIME_VERSION}")
+        adaptor_version = self._get_adaptor_package_version()
+        _logger.info(f"{self.adaptor_class.__name__} version: {adaptor_version}")
 
         interface_version_info = self._get_version_info()
 

--- a/test/openjd/adaptor_runtime/unit/test_entrypoint.py
+++ b/test/openjd/adaptor_runtime/unit/test_entrypoint.py
@@ -6,6 +6,7 @@ import argparse
 import json
 import os
 import signal
+import sys
 from pathlib import Path
 from typing import Optional
 from unittest.mock import ANY, MagicMock, Mock, PropertyMock, mock_open, patch
@@ -116,6 +117,25 @@ class TestStart:
             "OpenJD Adaptor CLI Version": str(runtime_entrypoint._ADAPTOR_CLI_VERSION),
             "MockAdaptor Data Interface Version": "1.5",
         }
+
+    def test_logs_versions_at_startup(self):
+        """Verifies that both the runtime and adaptor versions are logged during start()."""
+        # GIVEN
+        entrypoint = EntryPoint(FakeAdaptor)
+
+        with (
+            patch.object(entrypoint, "_get_adaptor_package_version", return_value="1.2.3"),
+            patch.object(runtime_entrypoint.sys, "argv", ["Adaptor", "run"]),
+            patch.object(runtime_entrypoint, "_logger") as mock_logger,
+        ):
+            # WHEN
+            entrypoint.start()
+
+        # THEN
+        mock_logger.info.assert_any_call(
+            f"openjd-adaptor-runtime version: {runtime_entrypoint._RUNTIME_VERSION}"
+        )
+        mock_logger.info.assert_any_call("FakeAdaptor version: 1.2.3")
 
     @pytest.mark.parametrize("integration_version", ["1.4", "1.5"])
     def test_is_compatible(
@@ -904,3 +924,166 @@ class TestLoadData:
 
         # THEN
         assert raised_err.match(f"Expected loaded data to be a dict, but got {type(input)}")
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 10),
+    reason="packages_distributions requires Python 3.10+",
+)
+class TestGetAdaptorPackageVersion:
+    """
+    Tests for the EntryPoint._get_adaptor_package_version method
+    """
+
+    def test_returns_version_from_distribution_file_match(self, mock_adaptor_cls: MagicMock):
+        """When the adaptor module file is found in a distribution's recorded files, return its version."""
+        # GIVEN
+        mock_adaptor_cls.__module__ = "deadline.max_adaptor.MaxAdaptor.adaptor"
+        entrypoint = EntryPoint(mock_adaptor_cls)
+
+        mock_dist = MagicMock()
+        mock_dist.version = "0.3.3"
+        mock_dist.files = [
+            MagicMock(__str__=lambda self: "deadline/max_adaptor/MaxAdaptor/adaptor.py"),
+            MagicMock(__str__=lambda self: "deadline/max_adaptor/__init__.py"),
+        ]
+
+        def fake_distribution(name):
+            if name == "deadline-cloud-for-3ds-max":
+                return mock_dist
+            raise runtime_entrypoint.importlib.metadata.PackageNotFoundError(name)
+
+        with (
+            patch(
+                "openjd.adaptor_runtime._entrypoint.importlib.metadata.packages_distributions",
+                return_value={"deadline": ["deadline-cloud-for-3ds-max", "deadline"]},
+            ),
+            patch(
+                "openjd.adaptor_runtime._entrypoint.importlib.metadata.distribution",
+                side_effect=fake_distribution,
+            ),
+        ):
+            # WHEN
+            result = entrypoint._get_adaptor_package_version()
+
+        # THEN
+        assert result == "0.3.3"
+
+    def test_does_not_match_wrong_distribution(self, mock_adaptor_cls: MagicMock):
+        """When the top-level package has multiple distributions, only match the correct one."""
+        # GIVEN
+        mock_adaptor_cls.__module__ = "deadline.max_adaptor.MaxAdaptor.adaptor"
+        entrypoint = EntryPoint(mock_adaptor_cls)
+
+        # deadline-cloud dist does NOT contain the adaptor module file
+        deadline_cloud_dist = MagicMock()
+        deadline_cloud_dist.version = "0.57.3"
+        deadline_cloud_dist.files = [
+            MagicMock(__str__=lambda self: "deadline/client/__init__.py"),
+            MagicMock(__str__=lambda self: "deadline/client/cli.py"),
+        ]
+
+        # deadline-cloud-for-3ds-max dist DOES contain the adaptor module file
+        max_adaptor_dist = MagicMock()
+        max_adaptor_dist.version = "0.3.3"
+        max_adaptor_dist.files = [
+            MagicMock(__str__=lambda self: "deadline/max_adaptor/MaxAdaptor/adaptor.py"),
+            MagicMock(__str__=lambda self: "deadline/max_adaptor/__init__.py"),
+        ]
+
+        def fake_distribution(name):
+            if name == "deadline":
+                return deadline_cloud_dist
+            if name == "deadline-cloud-for-3ds-max":
+                return max_adaptor_dist
+            raise runtime_entrypoint.importlib.metadata.PackageNotFoundError(name)
+
+        with (
+            patch(
+                "openjd.adaptor_runtime._entrypoint.importlib.metadata.packages_distributions",
+                return_value={"deadline": ["deadline", "deadline-cloud-for-3ds-max"]},
+            ),
+            patch(
+                "openjd.adaptor_runtime._entrypoint.importlib.metadata.distribution",
+                side_effect=fake_distribution,
+            ),
+        ):
+            # WHEN
+            result = entrypoint._get_adaptor_package_version()
+
+        # THEN
+        assert result == "0.3.3"
+
+    def test_falls_back_to_version_module(self, mock_adaptor_cls: MagicMock):
+        """When no distribution file match is found, fall back to _version module in sys.modules."""
+        # GIVEN
+        mock_adaptor_cls.__module__ = "deadline.max_adaptor.MaxAdaptor.adaptor"
+        entrypoint = EntryPoint(mock_adaptor_cls)
+
+        mock_version_module = MagicMock()
+        mock_version_module.version = "3.5.1"
+
+        with (
+            patch(
+                "openjd.adaptor_runtime._entrypoint.importlib.metadata.packages_distributions",
+                return_value={"deadline": []},
+            ),
+            patch.dict(
+                runtime_entrypoint.sys.modules,
+                {"deadline.max_adaptor._version": mock_version_module},
+            ),
+        ):
+            # WHEN
+            result = entrypoint._get_adaptor_package_version()
+
+        # THEN
+        assert result == "3.5.1"
+
+    def test_fallback_walks_up_module_path(self, mock_adaptor_cls: MagicMock):
+        """The _version fallback walks up the module path to find the correct _version module."""
+        # GIVEN
+        mock_adaptor_cls.__module__ = "deadline.max_adaptor.MaxAdaptor.adaptor"
+        entrypoint = EntryPoint(mock_adaptor_cls)
+
+        mock_version_module = MagicMock()
+        mock_version_module.version = "0.3.2"
+
+        with (
+            patch(
+                "openjd.adaptor_runtime._entrypoint.importlib.metadata.packages_distributions",
+                return_value={"deadline": []},
+            ),
+            patch.dict(
+                runtime_entrypoint.sys.modules,
+                {"deadline.max_adaptor._version": mock_version_module},
+            ),
+        ):
+            # WHEN
+            result = entrypoint._get_adaptor_package_version()
+
+        # THEN
+        assert result == "0.3.2"
+
+    def test_returns_unknown_when_version_not_found(self, mock_adaptor_cls: MagicMock):
+        """When no version can be determined, return 'UNKNOWN' and log a warning."""
+        # GIVEN
+        mock_adaptor_cls.__module__ = "deadline.max_adaptor.MaxAdaptor.adaptor"
+        mock_adaptor_cls.__name__ = "MaxAdaptor"
+        entrypoint = EntryPoint(mock_adaptor_cls)
+
+        with (
+            patch(
+                "openjd.adaptor_runtime._entrypoint.importlib.metadata.packages_distributions",
+                return_value={"deadline": []},
+            ),
+            patch.dict(runtime_entrypoint.sys.modules, {}, clear=False),
+        ):
+            runtime_entrypoint.sys.modules.pop("deadline.max_adaptor.MaxAdaptor._version", None)
+            runtime_entrypoint.sys.modules.pop("deadline.max_adaptor._version", None)
+            runtime_entrypoint.sys.modules.pop("deadline._version", None)
+
+            # WHEN
+            result = entrypoint._get_adaptor_package_version()
+
+        # THEN
+        assert result == "UNKNOWN"


### PR DESCRIPTION
Related to: https://github.com/aws-deadline/deadline-cloud-for-3ds-max/issues/216

### What was the problem/requirement? (What/Why)
When reporting issues with adaptors, it is hard to tell which version was used for a task run just from the task logs

### What was the solution? (How)
Print the version of the adaptor and the runtime at the start of a task run. This feature is currently only available for Python 3.10+, adaptors running on older Python versions will have an `UNKNOWN` version reported.

### What is the impact of this change?
The versions are in the task run logs

### How was this change tested?

- Add unit tests
- Test with a real adaptor: 3dsMax SMF worker with dev adaptor override (logs below)

#### 3dsMax task logs

```
2026/06/04 11:48:17-07:00 ----------------------------------------------
2026/06/04 11:48:17-07:00 Phase: Running action
2026/06/04 11:48:17-07:00 ----------------------------------------------
2026/06/04 11:48:17-07:00 Running command C:\Windows\System32\WindowsPowerShell\v1.0\powershell.EXE C:\Sessions\session-2e21fb36c8534791a1df86d48f13d16auy3m2u4x\embedded_filesjvsjloho\start.bat
2026/06/04 11:48:17-07:00 Command started as pid: 5916
2026/06/04 11:48:17-07:00 Output:
2026/06/04 11:48:17-07:00  
2026/06/04 11:48:17-07:00 C:\Sessions\session-2e21fb36c8534791a1df86d48f13d16auy3m2u4x>3dsmax-openjd daemon start --connection-file C:\Sessions\session-2e21fb36c8534791a1df86d48f13d16auy3m2u4x/connection.json --init-data file://C:\Sessions\session-2e21fb36c8534791a1df86d48f13d16auy3m2u4x\embedded_filesjvsjloho\init-data.yaml --path-mapping-rules file://C:\Sessions\session-2e21fb36c8534791a1df86d48f13d16auy3m2u4x\tmps1hiec3m.json 
2026/06/04 11:48:18-07:00 INFO: openjd-adaptor-runtime version: 0.9.4.post1+g4b5d67783
2026/06/04 11:48:18-07:00 INFO: MaxAdaptor version: 0.3.0
```

### Was this change documented?

No

### Is this a breaking change?

No

### Does this change impact security?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*