### PR TITLE
fix: retry LookupAccountName with exponential backoff to prevent ERROR_NONE_MAPPED on fresh EC2 instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,3 @@
-## Unreleased
-
-### Bug Fixes
-* fix: retry LookupAccountName with exponential backoff to prevent ERROR_NONE_MAPPED (1332) on freshly started EC2 instances
-
 ## 0.9.4 (2026-05-26)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+### Bug Fixes
+* fix: retry LookupAccountName with exponential backoff to prevent ERROR_NONE_MAPPED (1332) on freshly started EC2 instances
+
 ## 0.9.4 (2026-05-26)
 
 

--- a/src/openjd/adaptor_runtime_client/named_pipe/named_pipe_helper.py
+++ b/src/openjd/adaptor_runtime_client/named_pipe/named_pipe_helper.py
@@ -128,13 +128,23 @@ class NamedPipeHelper:
         # Get the username of the current user
         username = getpass.getuser()
 
-        # Get the SID for the current user
-        user_sid, _, _ = win32security.LookupAccountName(
-            "",  # systemName: The name of the system or server where the account resides.
-            # Search for the account on the local computer.
-            # If Domain/User Format is used here, it will fetch the Name from the AD.
-            username,
-        )
+        # Retry with exponential backoff to handle ERROR_NONE_MAPPED (1332) which occurs
+        # when the LSA service hasn't finished initializing on freshly started EC2 instances.
+        _LOOKUP_MAX_RETRIES = 3
+        for attempt in range(_LOOKUP_MAX_RETRIES):
+            try:
+                user_sid, _, _ = win32security.LookupAccountName(
+                    "",  # systemName: The name of the system or server where the account resides.
+                    # Search for the account on the local computer.
+                    # If Domain/User Format is used here, it will fetch the Name from the AD.
+                    username,
+                )
+                break
+            except pywintypes.error as e:
+                if e.winerror == 1332 and attempt < _LOOKUP_MAX_RETRIES - 1:
+                    time.sleep(2**attempt)
+                    continue
+                raise
 
         # Users who log on across a network. "S-1-5-2" is a group identifier added to the token of a process
         # when it was logged on across a network.

--- a/test/openjd/adaptor_runtime/unit/named_pipe/test_named_pipe_helper.py
+++ b/test/openjd/adaptor_runtime/unit/named_pipe/test_named_pipe_helper.py
@@ -104,7 +104,9 @@ class TestNamedPipeHelper:
     @patch("getpass.getuser", return_value="regularuser")
     def test_create_security_attributes_uses_lookup(self, mock_getuser):
         win32security = pytest.importorskip("win32security")
-        with patch.object(win32security, "LookupAccountName", return_value=("fake_sid", None, None)) as mock_lookup:
+        with patch.object(
+            win32security, "LookupAccountName", return_value=("fake_sid", None, None)
+        ) as mock_lookup:
             named_pipe_helper.NamedPipeHelper.create_security_attributes()
             mock_lookup.assert_called_once_with("", "regularuser")
 
@@ -114,7 +116,9 @@ class TestNamedPipeHelper:
         # ERROR_NONE_MAPPED (1332) is raised when LSA hasn't finished initializing on a
         # fresh EC2 instance. The lookup should retry with exponential backoff and succeed.
         win32security = pytest.importorskip("win32security")
-        lsa_error = pywintypes.error(1332, "LookupAccountName", "No mapping between account names and security IDs was done.")
+        lsa_error = pywintypes.error(
+            1332, "LookupAccountName", "No mapping between account names and security IDs was done."
+        )
         with patch.object(
             win32security, "LookupAccountName", side_effect=[lsa_error, ("fake_sid", None, None)]
         ) as mock_lookup:
@@ -127,7 +131,9 @@ class TestNamedPipeHelper:
     def test_create_security_attributes_raises_after_max_retries(self, mock_getuser, mock_sleep):
         # After exhausting all retries, the original error should be re-raised.
         win32security = pytest.importorskip("win32security")
-        lsa_error = pywintypes.error(1332, "LookupAccountName", "No mapping between account names and security IDs was done.")
+        lsa_error = pywintypes.error(
+            1332, "LookupAccountName", "No mapping between account names and security IDs was done."
+        )
         with patch.object(win32security, "LookupAccountName", side_effect=lsa_error):
             with pytest.raises(pywintypes.error) as exc_info:
                 named_pipe_helper.NamedPipeHelper.create_security_attributes()

--- a/test/openjd/adaptor_runtime/unit/named_pipe/test_named_pipe_helper.py
+++ b/test/openjd/adaptor_runtime/unit/named_pipe/test_named_pipe_helper.py
@@ -100,3 +100,35 @@ class TestNamedPipeHelper:
             match="Cannot find an available pipe name.",
         ):
             named_pipe_helper.NamedPipeHelper.generate_pipe_name("AdaptorTest")
+
+    @patch("getpass.getuser", return_value="regularuser")
+    def test_create_security_attributes_uses_lookup(self, mock_getuser):
+        win32security = pytest.importorskip("win32security")
+        with patch.object(win32security, "LookupAccountName", return_value=("fake_sid", None, None)) as mock_lookup:
+            named_pipe_helper.NamedPipeHelper.create_security_attributes()
+            mock_lookup.assert_called_once_with("", "regularuser")
+
+    @patch("time.sleep")
+    @patch("getpass.getuser", return_value="regularuser")
+    def test_create_security_attributes_retries_on_lsa_not_ready(self, mock_getuser, mock_sleep):
+        # ERROR_NONE_MAPPED (1332) is raised when LSA hasn't finished initializing on a
+        # fresh EC2 instance. The lookup should retry with exponential backoff and succeed.
+        win32security = pytest.importorskip("win32security")
+        lsa_error = pywintypes.error(1332, "LookupAccountName", "No mapping between account names and security IDs was done.")
+        with patch.object(
+            win32security, "LookupAccountName", side_effect=[lsa_error, ("fake_sid", None, None)]
+        ) as mock_lookup:
+            named_pipe_helper.NamedPipeHelper.create_security_attributes()
+            assert mock_lookup.call_count == 2
+            mock_sleep.assert_called_once_with(1)  # 2**0 = 1s after first failure
+
+    @patch("time.sleep")
+    @patch("getpass.getuser", return_value="regularuser")
+    def test_create_security_attributes_raises_after_max_retries(self, mock_getuser, mock_sleep):
+        # After exhausting all retries, the original error should be re-raised.
+        win32security = pytest.importorskip("win32security")
+        lsa_error = pywintypes.error(1332, "LookupAccountName", "No mapping between account names and security IDs was done.")
+        with patch.object(win32security, "LookupAccountName", side_effect=lsa_error):
+            with pytest.raises(pywintypes.error) as exc_info:
+                named_pipe_helper.NamedPipeHelper.create_security_attributes()
+            assert exc_info.value.winerror == 1332

--- a/test/openjd/adaptor_runtime/unit/named_pipe/test_named_pipe_helper.py
+++ b/test/openjd/adaptor_runtime/unit/named_pipe/test_named_pipe_helper.py
@@ -104,8 +104,9 @@ class TestNamedPipeHelper:
     @patch("getpass.getuser", return_value="regularuser")
     def test_create_security_attributes_uses_lookup(self, mock_getuser):
         win32security = pytest.importorskip("win32security")
+        fake_sid = win32security.ConvertStringSidToSid("S-1-1-0")
         with patch.object(
-            win32security, "LookupAccountName", return_value=("fake_sid", None, None)
+            win32security, "LookupAccountName", return_value=(fake_sid, None, None)
         ) as mock_lookup:
             named_pipe_helper.NamedPipeHelper.create_security_attributes()
             mock_lookup.assert_called_once_with("", "regularuser")
@@ -116,11 +117,12 @@ class TestNamedPipeHelper:
         # ERROR_NONE_MAPPED (1332) is raised when LSA hasn't finished initializing on a
         # fresh EC2 instance. The lookup should retry with exponential backoff and succeed.
         win32security = pytest.importorskip("win32security")
+        fake_sid = win32security.ConvertStringSidToSid("S-1-1-0")
         lsa_error = pywintypes.error(
             1332, "LookupAccountName", "No mapping between account names and security IDs was done."
         )
         with patch.object(
-            win32security, "LookupAccountName", side_effect=[lsa_error, ("fake_sid", None, None)]
+            win32security, "LookupAccountName", side_effect=[lsa_error, (fake_sid, None, None)]
         ) as mock_lookup:
             named_pipe_helper.NamedPipeHelper.create_security_attributes()
             assert mock_lookup.call_count == 2


### PR DESCRIPTION
## Summary

- `create_security_attributes()` calls `win32security.LookupAccountName("", username)` to resolve the current user's SID for named pipe access control
- This fails intermittently with `pywintypes.error: (1332, 'LookupAccountName', 'No mapping between account names and security IDs was done.')` on freshly started EC2 instances where the LSA (Local Security Authority) service has not finished initializing
- The failure is intermittent — re-runs pass because LSA is warm by then
- Add retry with exponential backoff (up to 3 attempts, sleeping 1s then 2s) on error 1332, then re-raise if all attempts are exhausted

## Affected repos

Fixes intermittent Windows integration test failures in all DCC repos that use `LOGNAME=SYSTEM` in their CodeBuild Windows environment: Cinema 4D, Blender, Houdini, Maya, 3ds Max, VRED, and Unreal Engine.

Related ticket: https://t.corp.amazon.com/P447504169

## Test plan

- [x] `test_create_security_attributes_uses_lookup`: verifies `LookupAccountName` is called with the current username
- [x] `test_create_security_attributes_retries_on_lsa_not_ready`: verifies retry succeeds after a transient 1332 error, with correct backoff sleep
- [x] `test_create_security_attributes_raises_after_max_retries`: verifies the original error is re-raised after exhausting all retries