### PR TITLE
chore(deps): combine and fix up dependabot bumps (black 26, mypy 2, pytest 9.1)

### DIFF
--- a/.github/scripts/get_latest_changelog.py
+++ b/.github/scripts/get_latest_changelog.py
@@ -29,6 +29,7 @@ Running this script on the above CHANGELOG.md should return the following conten
 
 ```
 """
+
 import re
 
 h2 = r"^##\s.*$"

--- a/hatch_version_hook.py
+++ b/hatch_version_hook.py
@@ -7,7 +7,6 @@ from dataclasses import dataclass
 from hatchling.builders.hooks.plugin.interface import BuildHookInterface
 from typing import Any, Optional
 
-
 _logger = logging.Logger(__name__, logging.INFO)
 _stdout_handler = logging.StreamHandler(sys.stdout)
 _stdout_handler.addFilter(lambda record: record.levelno <= logging.INFO)

--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -1,12 +1,14 @@
 coverage[toml] == 7.*
 coverage-conditional-plugin == 0.9.0
-pytest == 9.0.*; python_version >= '3.10'
+pytest == 9.1.*; python_version >= '3.10'
 pytest == 8.4.*; python_version < '3.10'
 pytest-cov == 7.1.*
 pytest-timeout == 2.4.*
 pytest-xdist == 3.8.*
-black == 25.*
+black == 26.*; python_version >= '3.10'
+black == 25.*; python_version < '3.10'
 ruff == 0.15.*
-mypy == 1.19.*
+mypy == 2.1.*; python_version >= '3.10'
+mypy == 1.19.*; python_version < '3.10'
 psutil == 7.2.*
 types-PyYAML ~= 6.0

--- a/src/openjd/adaptor_runtime/_background/backend_named_pipe_server.py
+++ b/src/openjd/adaptor_runtime/_background/backend_named_pipe_server.py
@@ -17,7 +17,6 @@ from .._named_pipe import NamedPipeServer
 from ..adaptors import AdaptorRunner
 from .log_buffers import LogBuffer
 
-
 _logger = logging.getLogger(__name__)
 
 

--- a/src/openjd/adaptor_runtime/_named_pipe/named_pipe_request_handler.py
+++ b/src/openjd/adaptor_runtime/_named_pipe/named_pipe_request_handler.py
@@ -20,7 +20,6 @@ from abc import ABC, abstractmethod
 
 from openjd.adaptor_runtime._osname import OSName
 
-
 _logger = logging.getLogger(__name__)
 
 

--- a/src/openjd/adaptor_runtime/_named_pipe/named_pipe_server.py
+++ b/src/openjd/adaptor_runtime/_named_pipe/named_pipe_server.py
@@ -32,7 +32,6 @@ from pywintypes import HANDLE
 
 from abc import ABC, abstractmethod
 
-
 _logger = logging.getLogger(__name__)
 
 

--- a/src/openjd/adaptor_runtime/adaptors/_validator.py
+++ b/src/openjd/adaptor_runtime/adaptors/_validator.py
@@ -9,7 +9,6 @@ import os
 import yaml
 from typing import Any
 
-
 _logger = logging.getLogger(__name__)
 
 

--- a/src/openjd/adaptor_runtime/process/_logging_subprocess.py
+++ b/src/openjd/adaptor_runtime/process/_logging_subprocess.py
@@ -1,6 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 """Module for the LoggingSubprocess class"""
+
 from __future__ import annotations
 
 import logging

--- a/src/openjd/adaptor_runtime/process/_managed_process.py
+++ b/src/openjd/adaptor_runtime/process/_managed_process.py
@@ -1,6 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 """Module for the ManagedProcess class"""
+
 from __future__ import annotations
 
 from abc import ABC as ABC, abstractmethod

--- a/src/openjd/adaptor_runtime/process/_stream_logger.py
+++ b/src/openjd/adaptor_runtime/process/_stream_logger.py
@@ -1,6 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 """Module for the StreamLogger class"""
+
 from __future__ import annotations
 
 import logging

--- a/src/openjd/adaptor_runtime_client/posix_client_interface.py
+++ b/src/openjd/adaptor_runtime_client/posix_client_interface.py
@@ -13,7 +13,6 @@ from .base_client_interface import BaseClientInterface
 from .connection import UnixHTTPConnection as _UnixHTTPConnection
 from urllib.parse import urlencode as _urlencode
 
-
 # Set timeout to None so our requests are blocking calls with no timeout.
 # See socket.settimeout
 _REQUEST_TIMEOUT = None

--- a/test/openjd/adaptor_runtime/unit/process/test_logging_subprocess.py
+++ b/test/openjd/adaptor_runtime/unit/process/test_logging_subprocess.py
@@ -1,6 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 """Tests for StreamLogger"""
+
 from __future__ import annotations
 
 import signal

--- a/test/openjd/adaptor_runtime/unit/process/test_stream_logger.py
+++ b/test/openjd/adaptor_runtime/unit/process/test_stream_logger.py
@@ -1,6 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 """Tests for LoggingSubprocess"""
+
 from __future__ import annotations
 
 import logging

--- a/test/openjd/adaptor_runtime/unit/test_entrypoint.py
+++ b/test/openjd/adaptor_runtime/unit/test_entrypoint.py
@@ -54,7 +54,11 @@ def mock_logging():
 
 @pytest.fixture(autouse=True)
 def mock_getLogger():
-    with patch.object(runtime_entrypoint.logging, "getLogger"):
+    # Patch EntryPoint._init_loggers (rather than the global logging.getLogger)
+    # so EntryPoint does not attach real handlers during tests. Patching
+    # logging.getLogger globally breaks pytest's caplog fixture on pytest >= 9.1,
+    # which relies on logging.getLogger to install its log-capture handler.
+    with patch.object(runtime_entrypoint.EntryPoint, "_init_loggers"):
         yield
 
 


### PR DESCRIPTION
Combining and fixing up the three failing dependabot PRs (#267, #269, #270) so they can be closed.

## Changes (`requirements-testing.txt`)
- **black `25.*` -> `26.*`** (#267)
- **mypy `1.19.*` -> `2.1.*`** (#269)
- **pytest `9.0.*` -> `9.1.*`** (#270)

## Why the individual PRs were failing

**1. black 26 / mypy 2 drop Python 3.9.** Both now require `>=3.10`, but this package supports `>=3.9` and tests it in CI. Fixed with environment markers (matching the pytest marker pattern already in the file) so the 3.9 job keeps the last compatible release and 3.10+ gets the new major:
```
pytest == 9.1.*; python_version >= '3.10'
pytest == 8.4.*; python_version < '3.10'
black == 26.*; python_version >= '3.10'
black == 25.*; python_version < '3.10'
mypy == 2.1.*; python_version >= '3.10'
mypy == 1.19.*; python_version < '3.10'
```
Also applied black 26's docstring blank-line reformatting; verified black 25 agrees with the reformatted tree so the 3.9 `black --check` job stays green.

**2. pytest 9.1 broke 7 tests in `test_entrypoint.py`.** pytest 9.1 reworked log capture for non-propagating loggers ([changelog #3697](https://docs.pytest.org/en/stable/changelog.html)). The autouse `mock_getLogger` fixture patched the **global** `logging.getLogger`, which pytest 9.1's `caplog` now relies on to install its capture handler — so `caplog.text` came back empty. Fixed by patching `EntryPoint._init_loggers` instead (the actual thing the fixture was trying to stub out), which works on both pytest 8.4 (the 3.9 job) and 9.1 (3.10+).

## Verification
- `ruff check` / `black --check` — pass
- `mypy` (2.1.0) — no issues in 146 source files
- `hatch run test` — 475 passed, 26 skipped
- Verified the 7 previously-failing tests pass under both pytest 8.4 and 9.1 (with xdist, matching CI)

Closes #267, closes #269, closes #270.