### PR TITLE
fix: decode subprocess output with errors="replace" to keep the reader thread alive

### DIFF
--- a/src/openjd/adaptor_runtime/process/_logging_subprocess.py
+++ b/src/openjd/adaptor_runtime/process/_logging_subprocess.py
@@ -64,6 +64,13 @@ class LoggingSubprocess(object):
             stderr=subprocess.PIPE,
             stdout=subprocess.PIPE,
             encoding=encoding,
+            # Decode the subprocess output leniently. DCC batch processes may emit
+            # locale-encoded (non-UTF-8) bytes on stdout/stderr; with the default strict
+            # error handling a single undecodable byte raises UnicodeDecodeError in the
+            # stream-reader thread, killing it. Once the reader thread is gone the pipe is
+            # no longer drained, the subprocess blocks on a full stdout pipe, and the job
+            # deadlocks. Replacing undecodable bytes keeps the reader alive.
+            errors="replace",
             cwd=startup_directory,
         )
         if OSName.is_windows():  # pragma: is-posix

--- a/test/openjd/adaptor_runtime/integ/process/test_integration_logging_subprocess.py
+++ b/test/openjd/adaptor_runtime/integ/process/test_integration_logging_subprocess.py
@@ -151,6 +151,37 @@ class TestIntegrationLoggingSubprocess(object):
 
         assert any(r.message == message and r.levelno == _STDERR_LEVEL for r in records)
 
+    @pytest.mark.timeout(10)
+    def test_non_utf8_output_does_not_kill_reader(self, caplog):
+        """
+        A subprocess that writes a non-UTF-8 (locale-encoded) byte to stdout must not kill the
+        stream-reader thread. If the reader thread dies, lines emitted after the undecodable byte
+        are never logged and the stdout pipe stops being drained, which can deadlock the subprocess.
+        This is a regression test for that failure mode; the undecodable byte must be tolerated and
+        subsequent output must still be logged.
+        """
+        # GIVEN
+        caplog.set_level(_STDOUT_LEVEL)
+        # 0xc7 is "Ç" in cp1252 and is not a valid standalone UTF-8 byte.
+        script = (
+            "import sys; "
+            "sys.stdout.buffer.write(b'before\\n'); "
+            "sys.stdout.buffer.write(b'bad \\xc7 byte\\n'); "
+            "sys.stdout.buffer.write(b'after\\n'); "
+            "sys.stdout.buffer.flush()"
+        )
+
+        # WHEN
+        p = LoggingSubprocess(args=[sys.executable, "-c", script])
+        p.wait()
+        p._cleanup_io_threads()
+
+        # THEN
+        # "after" is only logged if the reader thread survived the undecodable byte.
+        assert "after" in caplog.text
+        # The undecodable byte is replaced rather than raising.
+        assert "�" in caplog.text
+
     def test_executable_not_found(self):
         """When calling LoggingSubprocess with a missing executable, FileNotFoundError will be raised"""
         args = ["missing_executable"]

--- a/test/openjd/adaptor_runtime/unit/process/test_logging_subprocess.py
+++ b/test/openjd/adaptor_runtime/unit/process/test_logging_subprocess.py
@@ -69,6 +69,7 @@ class TestLoggingSubprocess(object):
         popen_params = dict(
             args=args,
             encoding="utf-8",
+            errors="replace",
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
@@ -482,6 +483,7 @@ class TestLoggingSubprocess(object):
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             encoding="utf-8",
+            errors="replace",
             cwd=None,
         )
         if OSName.is_windows():
@@ -504,6 +506,7 @@ class TestLoggingSubprocess(object):
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             encoding="utf-8",
+            errors="replace",
             cwd="startup_dir",
         )
         if OSName.is_windows():


### PR DESCRIPTION
Fixes: https://github.com/OpenJobDescription/openjd-adaptor-runtime-for-python/issues/274

### What was the problem/requirement? (What/Why)

`LoggingSubprocess` decodes the child process's stdout/stderr with `subprocess.Popen(..., encoding="utf-8")` and no `errors` argument, i.e. the strict error handler.

When a subprocess writes a byte that is not valid UTF-8 (common for DCC batch renderers that emit locale-encoded text, e.g. cp1252 on Windows), `StreamLogger.run`'s `readline()` raises `UnicodeDecodeError`. Since `UnicodeDecodeError` is a subclass of `ValueError` and `StreamLogger.run` re-raises any `ValueError` other than "I/O operation on closed file", the stdout reader thread (`AdaptorRuntimeStdoutLogger`) dies. After that the stdout pipe is no longer drained, the subprocess blocks on a full pipe, and the job hangs indefinitely. The failure is silent, which makes it hard to diagnose.

This was observed in production with the AWS Deadline Cloud 3ds Max adaptor: `3dsmaxbatch.exe` emits byte `0xc7` on stdout and rendering hangs partway through.

### What was the solution? (How)

Pass `errors="replace"` to the `Popen` call in `_logging_subprocess.py` so subprocess output is decoded leniently. Undecodable bytes are replaced with the Unicode replacement character instead of raising, so the reader thread stays alive, the pipe keeps being drained, and no log lines are dropped.

The fix is intentionally minimal and focused on the decode path. Making `StreamLogger.run` itself more resilient to unexpected read/log errors is discussed in the linked issue and left out of this PR to keep it focused.

### What is the impact of this change?

Jobs whose subprocesses emit non-UTF-8 bytes on stdout/stderr no longer risk a silent reader-thread death and deadlock. Log output is preserved, with any undecodable byte shown as the replacement character.

### How was this change tested?

- Added a regression integration test (`test_non_utf8_output_does_not_kill_reader`) that runs a subprocess emitting byte `0xc7` on stdout and asserts that lines after the undecodable byte are still logged (i.e. the reader thread survived). Verified that this test fails on the unmodified code and passes with the fix.
- Updated the existing `Popen` argument assertions in the unit tests to include `errors="replace"`.
- Ran the unit and integration tests for the `process` package locally (41 passed, 1 skipped — the skipped test is Windows-only).

- Have you run the unit tests? Yes.

### Was this change documented?

- Are relevant docstrings in the code base updated? A code comment explaining why lenient decoding is required was added at the `Popen` call site. No public docstrings needed changes.

### Is this a breaking change?

No. This does not change any public interface. The only behavioral change is that previously-undecodable bytes are now replaced instead of killing the reader thread.

### Does this change impact security?

No. It does not create or modify files/directories or change any trust boundary.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
