### PR TITLE
fix: escape undecodable subprocess output bytes and deflake graceful shutdown test

### DIFF
--- a/src/openjd/adaptor_runtime/process/_logging_subprocess.py
+++ b/src/openjd/adaptor_runtime/process/_logging_subprocess.py
@@ -69,8 +69,12 @@ class LoggingSubprocess(object):
             # error handling a single undecodable byte raises UnicodeDecodeError in the
             # stream-reader thread, killing it. Once the reader thread is gone the pipe is
             # no longer drained, the subprocess blocks on a full stdout pipe, and the job
-            # deadlocks. Replacing undecodable bytes keeps the reader alive.
-            errors="replace",
+            # deadlocks. Escaping undecodable bytes (e.g. b"\xc7" -> "\\xc7") keeps the
+            # reader alive while preserving the original byte values in the logs, which
+            # helps identify the codepage the subprocess is emitting.
+            # Note: encoding/errors also apply to stdin, so text written to the child's
+            # stdin would have unencodable characters escaped silently rather than raising.
+            errors="backslashreplace",
             cwd=startup_directory,
         )
         if OSName.is_windows():  # pragma: is-posix

--- a/test/openjd/adaptor_runtime/integ/process/test_integration_logging_subprocess.py
+++ b/test/openjd/adaptor_runtime/integ/process/test_integration_logging_subprocess.py
@@ -174,13 +174,77 @@ class TestIntegrationLoggingSubprocess(object):
         # WHEN
         p = LoggingSubprocess(args=[sys.executable, "-c", script])
         p.wait()
-        p._cleanup_io_threads()
 
         # THEN
         # "after" is only logged if the reader thread survived the undecodable byte.
         assert "after" in caplog.text
-        # The undecodable byte is replaced rather than raising.
-        assert "�" in caplog.text
+        # The undecodable byte is escaped rather than raising.
+        assert "bad \\xc7 byte" in caplog.text
+
+    @pytest.mark.timeout(10)
+    @pytest.mark.parametrize(
+        argnames=("raw_bytes", "expected_escaped"),
+        argvalues=[
+            # 0xc7 is "Ç" in cp1252 (observed from 3dsmaxbatch.exe on stdout).
+            (b"bad \xc7 byte", "bad \\xc7 byte"),
+            # 0xff is never valid anywhere in UTF-8.
+            (b"bad \xff byte", "bad \\xff byte"),
+            # Consecutive invalid bytes must each be escaped separately.
+            (b"bad \xc7\xff bytes", "bad \\xc7\\xff bytes"),
+            # cp1252-encoded "Çé" — an invalid two-byte run in UTF-8.
+            (b"bad \xc7\xe9 text", "bad \\xc7\\xe9 text"),
+            # A truncated UTF-8 multi-byte sequence (0xe4 0xbd is an incomplete
+            # 3-byte sequence) followed by valid ASCII.
+            (b"truncated \xe4\xbd then ok", "truncated \\xe4\\xbd then ok"),
+        ],
+        ids=["cp1252-byte", "invalid-byte", "consecutive-invalid", "cp1252-text", "truncated-utf8"],
+    )
+    def test_non_utf8_output_is_escaped(self, caplog, raw_bytes: bytes, expected_escaped: str):
+        """
+        Undecodable bytes in subprocess output must be escaped with backslashreplace
+        (e.g. b"\xc7" -> "\\xc7") so the original byte values are preserved in the logs.
+        """
+        # GIVEN
+        caplog.set_level(_STDOUT_LEVEL)
+        script = (
+            "import sys; "
+            f"sys.stdout.buffer.write({raw_bytes + b'!'!r}); "
+            "sys.stdout.buffer.flush()"
+        )
+
+        # WHEN
+        p = LoggingSubprocess(args=[sys.executable, "-c", script])
+        p.wait()
+
+        # THEN
+        # The trailing "!" proves the full line was logged, not truncated at the bad byte.
+        assert expected_escaped + "!" in caplog.text
+        # The replacement character must not appear; the byte value must be preserved.
+        assert "�" not in caplog.text
+
+    @pytest.mark.timeout(10)
+    def test_valid_utf8_is_not_escaped(self, caplog):
+        """
+        Valid multi-byte UTF-8 sequences must pass through unmodified — escaping applies
+        only to genuinely invalid sequences, even when a multi-byte character could be
+        split across internal read chunk boundaries.
+        """
+        # GIVEN
+        caplog.set_level(_STDOUT_LEVEL)
+        message = "héllo wörld Ç 星期五"
+        script = (
+            "import sys; "
+            f"sys.stdout.buffer.write({message.encode('utf-8')!r} + b'\\n'); "
+            "sys.stdout.buffer.flush()"
+        )
+
+        # WHEN
+        p = LoggingSubprocess(args=[sys.executable, "-c", script])
+        p.wait()
+
+        # THEN
+        assert message in caplog.text
+        assert "\\x" not in caplog.text
 
     def test_executable_not_found(self):
         """When calling LoggingSubprocess with a missing executable, FileNotFoundError will be raised"""

--- a/test/openjd/adaptor_runtime/unit/process/test_logging_subprocess.py
+++ b/test/openjd/adaptor_runtime/unit/process/test_logging_subprocess.py
@@ -69,7 +69,7 @@ class TestLoggingSubprocess(object):
         popen_params = dict(
             args=args,
             encoding="utf-8",
-            errors="replace",
+            errors="backslashreplace",
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
@@ -483,7 +483,7 @@ class TestLoggingSubprocess(object):
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             encoding="utf-8",
-            errors="replace",
+            errors="backslashreplace",
             cwd=None,
         )
         if OSName.is_windows():
@@ -506,7 +506,7 @@ class TestLoggingSubprocess(object):
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             encoding="utf-8",
-            errors="replace",
+            errors="backslashreplace",
             cwd="startup_dir",
         )
         if OSName.is_windows():

--- a/test/openjd/adaptor_runtime_client/integ/fake_client.py
+++ b/test/openjd/adaptor_runtime_client/integ/fake_client.py
@@ -37,6 +37,9 @@ class FakeClient(_ClientInterface):
 
 def run_client():
     test_client = FakeClient("1234")
+    # Signal handler registration (in the main thread) happens in the constructor above.
+    # Tests wait for this line before sending signals to avoid a startup race.
+    print("client ready", flush=True)
     test_client.run()
 
 

--- a/test/openjd/adaptor_runtime_client/integ/test_integration_client_interface.py
+++ b/test/openjd/adaptor_runtime_client/integ/test_integration_client_interface.py
@@ -33,8 +33,13 @@ class TestIntegrationClientInterface:
             popen_params.update(creationflags=_subprocess.CREATE_NEW_PROCESS_GROUP)  # type: ignore[attr-defined]
         client_subprocess = _subprocess.Popen(**popen_params)
 
-        # To avoid a race condition, giving some extra time for the logging subprocess to start.
-        _sleep(0.5 if OSName.is_posix() else 4)
+        # Wait for the client to report that it has started (and registered its signal
+        # handler) before sending the signal. A fixed sleep is racy on slow CI hosts: if the
+        # signal arrives before the handler is registered, the default handler kills the
+        # process and the test fails with empty output.
+        assert client_subprocess.stdout is not None
+        ready_line = client_subprocess.stdout.readline()
+        assert "client ready" in ready_line
         signal_type: signal.Signals
         if OSName.is_windows():
             signal_type = signal.CTRL_BREAK_EVENT  # type: ignore[attr-defined]


### PR DESCRIPTION
Follow-up to #275.

### What was the problem/requirement? (What/Why)

Two things left over from #275:

1. **`errors="replace"` discards the original byte value.** The review on #275 recommended `backslashreplace` instead: it keeps the stream-reader thread alive exactly the same way, but renders an undecodable byte as `\xc7` instead of `�`, preserving the byte value in the logs. That is genuinely useful when debugging which codepage a DCC batch renderer is emitting — the very scenario that motivated the original fix — and it is what CPython itself uses for its own stderr.

2. **`test_graceful_shutdown` is flaky.** The Python 3.12 macOS CI job on #275 failed (attempt 2) with `AssertionError: assert 'Received SIGTERM signal.' in ''` and only passed on re-run. The test spawned `fake_client.py`, slept a fixed 0.5 s, then sent SIGTERM. On a slow CI host the signal can arrive before the client registers its signal handler in `HTTPClientInterface.__init__`, so the default handler kills the process and stdout is empty. The failure is timing-dependent, not 3.12-specific.

### What was the solution? (How)

1. Switched the `Popen` decode error handler in `_logging_subprocess.py` from `replace` to `backslashreplace`, expanded the call-site comment (including a note that `encoding`/`errors` also apply to stdin), and updated the three `Popen` argument assertions in the unit tests.
2. Replaced the fixed sleep with a handshake: `fake_client.py` now prints a flushed `client ready` line after its constructor (which registers the signal handler) returns, and the test blocks on `stdout.readline()` for that line before sending the signal.

Also removed the redundant `p._cleanup_io_threads()` call in the regression test from #275 — `p.wait()` already performs the cleanup on every path.

### What is the impact of this change?

Undecodable bytes in subprocess output now appear in logs as their escaped byte value (e.g. `\xc7`) instead of the replacement character, so no forensic information is lost. The graceful-shutdown integration test no longer depends on a fixed startup sleep.

### How was this change tested?

- New parametrized integration test `test_non_utf8_output_is_escaped` covering: a single cp1252 byte (`0xc7`, observed from `3dsmaxbatch.exe`), `0xff` (never valid in UTF-8), consecutive invalid bytes, a cp1252 two-byte run, and a truncated UTF-8 multi-byte sequence. Each case asserts the exact escaped form is logged, the full line is preserved, and no `U+FFFD` appears.
- New integration test `test_valid_utf8_is_not_escaped` asserting valid multi-byte UTF-8 (`héllo wörld Ç 星期五`) passes through unmodified.
- Updated the #275 regression test to assert the escaped form.
- Ran the previously flaky `test_graceful_shutdown` 10× consecutively on Python 3.12 — stable.
- Full suite on Python 3.12: 482 passed, 26 skipped. `ruff`, `black --check`, and `mypy` all clean.

- Have you run the unit tests? Yes.

### Was this change documented?

The comment at the `Popen` call site was updated to explain the escaping behavior and the stdin caveat. No public docstrings needed changes.

### Is this a breaking change?

No. The only behavioral change is that previously-replaced undecodable bytes are now rendered as escaped byte values in logs.

### Does this change impact security?

No. `backslashreplace` only affects invalid byte sequences; it cannot synthesize newlines or control characters, and it does not change any trust boundary.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*